### PR TITLE
feat: 회원 기능 API 구현

### DIFF
--- a/src/main/java/com/chaeum/api/domain/attendance/entity/Attendance.java
+++ b/src/main/java/com/chaeum/api/domain/attendance/entity/Attendance.java
@@ -1,5 +1,27 @@
 package com.chaeum.api.domain.attendance.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "attendance")
 public class Attendance {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 }

--- a/src/main/java/com/chaeum/api/domain/cat/entity/Cat.java
+++ b/src/main/java/com/chaeum/api/domain/cat/entity/Cat.java
@@ -51,7 +51,7 @@ public class Cat extends BaseEntity {
     @Column(name = "experience_point", nullable = false)
     private BigInteger experiencePoint;
 
-    public static Cat toEntity(Member member) {
+    public static Cat create(Member member) {
         return Cat.builder()
                 .member(member)
                 .level(1)

--- a/src/main/java/com/chaeum/api/domain/cat/entity/Cat.java
+++ b/src/main/java/com/chaeum/api/domain/cat/entity/Cat.java
@@ -15,9 +15,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -49,9 +51,17 @@ public class Cat extends BaseEntity {
     @Column(name = "experience_point", nullable = false)
     private BigInteger experiencePoint;
 
+    public static Cat toEntity(Member member) {
+        return Cat.builder()
+                .member(member)
+                .level(1)
+                .experiencePoint(BigInteger.ZERO)
+                .build();
+    }
+
     @Transient
     private static LevelUpStrategy levelUpStrategy =
-        new PowerLevelUpStrategy(LevelUpConstants.BASE_EXP, LevelUpConstants.EXPONENT);
+            new PowerLevelUpStrategy(LevelUpConstants.BASE_EXP, LevelUpConstants.EXPONENT);
 
     public List<Integer> addExpAndGetLevelUps(BigInteger gainedExp) {
         this.experiencePoint = this.experiencePoint.add(gainedExp);

--- a/src/main/java/com/chaeum/api/domain/cat/repository/CatRepository.java
+++ b/src/main/java/com/chaeum/api/domain/cat/repository/CatRepository.java
@@ -1,7 +1,9 @@
 package com.chaeum.api.domain.cat.repository;
 
 import com.chaeum.api.domain.cat.entity.Cat;
+
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface CatRepository extends JpaRepository<Cat, Long> {
 
     Optional<Cat> findByMemberId(Long memberId);
+
+    boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/com/chaeum/api/domain/cat/service/CatService.java
+++ b/src/main/java/com/chaeum/api/domain/cat/service/CatService.java
@@ -39,7 +39,7 @@ public class CatService {
     @Transactional
     public void registerCatForMember(Member member) {
         if (catRepository.existsByMemberId(member.getId())) return;
-        catRepository.save(Cat.toEntity(member));
+        catRepository.save(Cat.create(member));
     }
 
     public Cat findByMemberId(Long memberId) {

--- a/src/main/java/com/chaeum/api/domain/cat/service/CatService.java
+++ b/src/main/java/com/chaeum/api/domain/cat/service/CatService.java
@@ -4,7 +4,7 @@ import com.chaeum.api.domain.cat.dto.response.CatInformationResponse;
 import com.chaeum.api.domain.cat.entity.Cat;
 import com.chaeum.api.domain.cat.repository.CatRepository;
 import com.chaeum.api.domain.member.entity.Member;
-import com.chaeum.api.domain.member.service.MemberService;
+import com.chaeum.api.global.auth.util.LoginMemberProvider;
 import com.chaeum.api.global.exception.ChaeumException;
 import com.chaeum.api.global.exception.ErrorCode;
 
@@ -20,18 +20,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class CatService {
 
     private final CatRepository catRepository;
-    private final MemberService memberService;
+    private final LoginMemberProvider loginMemberProvider;
 
     @Transactional(readOnly = true)
     public CatInformationResponse getMyCatInformation() {
-        Long memberId = memberService.getCurrentLoginMemberId();
+        Long memberId = loginMemberProvider.getCurrentLoginMemberId();
         Cat cat = findByMemberId(memberId);
         return CatInformationResponse.toDto(cat);
     }
 
     @Transactional
     public List<Integer> addExperience(BigInteger gainedExp) {
-        Long memberId = memberService.getCurrentLoginMemberId();
+        Long memberId = loginMemberProvider.getCurrentLoginMemberId();
         Cat cat = findByMemberId(memberId);
         return cat.addExpAndGetLevelUps(gainedExp);
     }

--- a/src/main/java/com/chaeum/api/domain/cat/service/CatService.java
+++ b/src/main/java/com/chaeum/api/domain/cat/service/CatService.java
@@ -7,8 +7,10 @@ import com.chaeum.api.domain.member.entity.Member;
 import com.chaeum.api.domain.member.service.MemberService;
 import com.chaeum.api.global.exception.ChaeumException;
 import com.chaeum.api.global.exception.ErrorCode;
+
 import java.math.BigInteger;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,8 +36,14 @@ public class CatService {
         return cat.addExpAndGetLevelUps(gainedExp);
     }
 
+    @Transactional
+    public void registerCatForMember(Member member) {
+        if (catRepository.existsByMemberId(member.getId())) return;
+        catRepository.save(Cat.toEntity(member));
+    }
+
     public Cat findByMemberId(Long memberId) {
         return catRepository.findByMemberId(memberId)
-            .orElseThrow(() -> ChaeumException.from(ErrorCode.CAT_NOT_FOUND));
+                .orElseThrow(() -> ChaeumException.from(ErrorCode.CAT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/chaeum/api/domain/donation/controller/DonationController.java
+++ b/src/main/java/com/chaeum/api/domain/donation/controller/DonationController.java
@@ -1,4 +1,16 @@
 package com.chaeum.api.domain.donation.controller;
 
+import com.chaeum.api.domain.donation.service.DonationService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/donation")
+@RequiredArgsConstructor
+@Tag(name = "Donation", description = "기부 관리")
 public class DonationController {
+
+    private final DonationService donationService;
 }

--- a/src/main/java/com/chaeum/api/domain/donation/dto/response/DonationSummaryResponse.java
+++ b/src/main/java/com/chaeum/api/domain/donation/dto/response/DonationSummaryResponse.java
@@ -1,0 +1,30 @@
+package com.chaeum.api.domain.donation.dto.response;
+
+import com.chaeum.api.domain.donation.entity.Donation;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class DonationSummaryResponse {
+
+    private String title;
+
+    private String imageUrl;
+
+    private BigDecimal amount;
+
+    private LocalDateTime createdAt;
+
+    public static DonationSummaryResponse toDto(Donation donation) {
+        return DonationSummaryResponse.builder()
+                .title(donation.getFunding().getTitle())
+                .imageUrl(donation.getFunding().getFundingImage())
+                .amount(donation.getAmount())
+                .createdAt(donation.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/chaeum/api/domain/donation/dto/response/DonationSummaryResponse.java
+++ b/src/main/java/com/chaeum/api/domain/donation/dto/response/DonationSummaryResponse.java
@@ -11,6 +11,8 @@ import java.time.LocalDateTime;
 @Builder
 public class DonationSummaryResponse {
 
+    private Long id;
+
     private String title;
 
     private String imageUrl;

--- a/src/main/java/com/chaeum/api/domain/donation/entity/Donation.java
+++ b/src/main/java/com/chaeum/api/domain/donation/entity/Donation.java
@@ -2,6 +2,7 @@ package com.chaeum.api.domain.donation.entity;
 
 import com.chaeum.api.domain.funding.entity.Funding;
 import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -27,7 +28,7 @@ import java.math.BigDecimal;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "donation")
-public class Donation {
+public class Donation extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/chaeum/api/domain/donation/entity/Donation.java
+++ b/src/main/java/com/chaeum/api/domain/donation/entity/Donation.java
@@ -5,6 +5,8 @@ import com.chaeum.api.domain.member.entity.Member;
 import com.chaeum.api.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -46,6 +48,7 @@ public class Donation extends BaseEntity {
     @Column(name = "amount")
     private BigDecimal amount;
 
-    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
     private DonationStatus status;
 }

--- a/src/main/java/com/chaeum/api/domain/donation/entity/Donation.java
+++ b/src/main/java/com/chaeum/api/domain/donation/entity/Donation.java
@@ -1,4 +1,29 @@
 package com.chaeum.api.domain.donation.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "donation")
 public class Donation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "donation_id")
+    private Long id;
 }

--- a/src/main/java/com/chaeum/api/domain/donation/entity/Donation.java
+++ b/src/main/java/com/chaeum/api/domain/donation/entity/Donation.java
@@ -1,10 +1,15 @@
 package com.chaeum.api.domain.donation.entity;
 
+import com.chaeum.api.domain.funding.entity.Funding;
+import com.chaeum.api.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,6 +17,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.math.BigDecimal;
 
 @Entity
 @Getter
@@ -26,4 +33,18 @@ public class Donation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "donation_id")
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "funding_id", nullable = false)
+    private Funding funding;
+
+    @Column(name = "amount")
+    private BigDecimal amount;
+
+    @Column(name = "status")
+    private DonationStatus status;
 }

--- a/src/main/java/com/chaeum/api/domain/donation/entity/DonationStatus.java
+++ b/src/main/java/com/chaeum/api/domain/donation/entity/DonationStatus.java
@@ -1,0 +1,17 @@
+package com.chaeum.api.domain.donation.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DonationStatus {
+
+    ONGOING("ONGOING", "진행 중"),
+    COMPLETED("COMPLETED", "완료"),
+    FAILED("FAILED", "실패"),
+    CANCELED("CANCELED", "취소됨");
+
+    private final String key;
+    private final String description;
+}

--- a/src/main/java/com/chaeum/api/domain/donation/repository/DonationRepository.java
+++ b/src/main/java/com/chaeum/api/domain/donation/repository/DonationRepository.java
@@ -1,4 +1,28 @@
 package com.chaeum.api.domain.donation.repository;
 
-public interface DonationRepository {
+import com.chaeum.api.domain.donation.entity.Donation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DonationRepository extends JpaRepository<Donation, Long> {
+
+    List<Donation> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+    @Query(value = "SELECT * FROM donation d " +
+            "WHERE d.member_id = :memberId " +
+            "AND EXTRACT(YEAR FROM d.created_at) = :year " +
+            "AND EXTRACT(MONTH FROM d.created_at) = :month",
+            nativeQuery = true)
+    List<Donation> findByMemberIdAndYearAndMonth(@Param("memberId") Long memberId, @Param("year") int year, @Param("month") int month);
+
+    @Query(value = "SELECT * FROM donation d " +
+            "WHERE d.member_id = :memberId " +
+            "AND EXTRACT(YEAR FROM d.created_at) = :year",
+            nativeQuery = true)
+    List<Donation> findByMemberIdAndYear(@Param("memberId") Long memberId, @Param("year") int year);
 }

--- a/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
+++ b/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
@@ -4,10 +4,10 @@ import com.chaeum.api.domain.donation.entity.Donation;
 import com.chaeum.api.domain.donation.repository.DonationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +15,7 @@ public class DonationService {
 
     private final DonationRepository donationRepository;
 
+    @Transactional(readOnly = true)
     public BigDecimal getThisMonthTotalByMemberId(Long memberId) {
         LocalDateTime now = LocalDateTime.now();
         int currentYear = now.getYear();
@@ -25,6 +26,7 @@ public class DonationService {
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
+    @Transactional(readOnly = true)
     public BigDecimal getThisYearTotalByMemberId(Long memberId) {
         int currentYear = LocalDateTime.now().getYear();
 

--- a/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
+++ b/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
@@ -1,4 +1,44 @@
 package com.chaeum.api.domain.donation.service;
 
+import com.chaeum.api.domain.donation.entity.Donation;
+import com.chaeum.api.domain.donation.repository.DonationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class DonationService {
+
+    private final DonationRepository donationRepository;
+
+    public BigDecimal getThisMonthTotalByMember(Long memberId) {
+        LocalDateTime now = LocalDateTime.now();
+        int currentYear = now.getYear();
+        int currentMonth = now.getMonthValue();
+
+        List<Donation> donations = donationRepository.findByMemberIdAndYearAndMonth(memberId, currentYear, currentMonth);
+        BigDecimal total = BigDecimal.ZERO;
+
+        for (Donation donation : donations) {
+            total = total.add(donation.getAmount());
+        }
+
+        return total;
+    }
+
+    public BigDecimal getThisYearTotalByMember(Long memberId) {
+        int currentYear = LocalDateTime.now().getYear();
+        List<Donation> donations = donationRepository.findByMemberIdAndYear(memberId, currentYear);
+        BigDecimal total = BigDecimal.ZERO;
+
+        for (Donation donation : donations) {
+            total = total.add(donation.getAmount());
+        }
+
+        return total;
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
+++ b/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
@@ -20,25 +20,16 @@ public class DonationService {
         int currentYear = now.getYear();
         int currentMonth = now.getMonthValue();
 
-        List<Donation> donations = donationRepository.findByMemberIdAndYearAndMonth(memberId, currentYear, currentMonth);
-        BigDecimal total = BigDecimal.ZERO;
-
-        for (Donation donation : donations) {
-            total = total.add(donation.getAmount());
-        }
-
-        return total;
+        return donationRepository.findByMemberIdAndYearAndMonth(memberId, currentYear, currentMonth).stream()
+                .map(Donation::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     public BigDecimal getThisYearTotalByMemberId(Long memberId) {
         int currentYear = LocalDateTime.now().getYear();
-        List<Donation> donations = donationRepository.findByMemberIdAndYear(memberId, currentYear);
-        BigDecimal total = BigDecimal.ZERO;
 
-        for (Donation donation : donations) {
-            total = total.add(donation.getAmount());
-        }
-
-        return total;
+        return donationRepository.findByMemberIdAndYear(memberId, currentYear).stream()
+                .map(Donation::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 }

--- a/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
+++ b/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
@@ -1,5 +1,6 @@
 package com.chaeum.api.domain.donation.service;
 
+import com.chaeum.api.domain.donation.dto.response.DonationSummaryResponse;
 import com.chaeum.api.domain.donation.entity.Donation;
 import com.chaeum.api.domain.donation.repository.DonationRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -33,5 +35,12 @@ public class DonationService {
         return donationRepository.findByMemberIdAndYear(memberId, currentYear).stream()
                 .map(Donation::getAmount)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DonationSummaryResponse> getDonationSummariesByMemberId(Long memberId) {
+        return donationRepository.findByMemberIdOrderByCreatedAtDesc(memberId).stream()
+                .map(DonationSummaryResponse::toDto)
+                .toList();
     }
 }

--- a/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
+++ b/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
@@ -15,7 +15,7 @@ public class DonationService {
 
     private final DonationRepository donationRepository;
 
-    public BigDecimal getThisMonthTotalByMember(Long memberId) {
+    public BigDecimal getThisMonthTotalByMemberId(Long memberId) {
         LocalDateTime now = LocalDateTime.now();
         int currentYear = now.getYear();
         int currentMonth = now.getMonthValue();
@@ -30,7 +30,7 @@ public class DonationService {
         return total;
     }
 
-    public BigDecimal getThisYearTotalByMember(Long memberId) {
+    public BigDecimal getThisYearTotalByMemberId(Long memberId) {
         int currentYear = LocalDateTime.now().getYear();
         List<Donation> donations = donationRepository.findByMemberIdAndYear(memberId, currentYear);
         BigDecimal total = BigDecimal.ZERO;

--- a/src/main/java/com/chaeum/api/domain/friendship/entity/Friendship.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/entity/Friendship.java
@@ -1,4 +1,27 @@
 package com.chaeum.api.domain.friendship.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "friendship")
 public class Friendship {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 }

--- a/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingSummaryResponse.java
+++ b/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingSummaryResponse.java
@@ -1,0 +1,29 @@
+package com.chaeum.api.domain.funding.dto.response;
+
+import com.chaeum.api.domain.funding.entity.Funding;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class FundingSummaryResponse {
+
+    private String title;
+
+    private String fundingImage;
+
+    private BigDecimal amount;
+
+    private LocalDateTime createdAt;
+
+    public static FundingSummaryResponse toDto(Funding funding){
+        return FundingSummaryResponse.builder()
+                .title(funding.getTitle())
+                .fundingImage(funding.getFundingImage())
+                .amount(funding.getCurrentAmount())
+                .build();
+    }
+}

--- a/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingSummaryResponse.java
+++ b/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingSummaryResponse.java
@@ -11,6 +11,8 @@ import java.time.LocalDateTime;
 @Builder
 public class FundingSummaryResponse {
 
+    private Long id;
+
     private String title;
 
     private String fundingImage;

--- a/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingSummaryResponse.java
+++ b/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingSummaryResponse.java
@@ -21,8 +21,9 @@ public class FundingSummaryResponse {
 
     private LocalDateTime createdAt;
 
-    public static FundingSummaryResponse toDto(Funding funding){
+    public static FundingSummaryResponse toDto(Funding funding) {
         return FundingSummaryResponse.builder()
+                .id(funding.getId())
                 .title(funding.getTitle())
                 .fundingImage(funding.getFundingImage())
                 .amount(funding.getCurrentAmount())

--- a/src/main/java/com/chaeum/api/domain/funding/repository/FundingRepository.java
+++ b/src/main/java/com/chaeum/api/domain/funding/repository/FundingRepository.java
@@ -12,4 +12,6 @@ import java.util.List;
 public interface FundingRepository extends JpaRepository<Funding, Long> {
 
     List<Funding> findByStatusAndEndDateBefore(FundingStatus status, LocalDateTime endDate);
+
+    List<Funding> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 }

--- a/src/main/java/com/chaeum/api/domain/funding/service/FundingService.java
+++ b/src/main/java/com/chaeum/api/domain/funding/service/FundingService.java
@@ -3,6 +3,7 @@ package com.chaeum.api.domain.funding.service;
 import com.chaeum.api.domain.funding.dto.request.FundingCreateRequest;
 import com.chaeum.api.domain.funding.dto.request.FundingUpdateRequest;
 import com.chaeum.api.domain.funding.dto.response.FundingResponse;
+import com.chaeum.api.domain.funding.dto.response.FundingSummaryResponse;
 import com.chaeum.api.domain.funding.entity.Funding;
 import com.chaeum.api.domain.funding.entity.FundingStatus;
 import com.chaeum.api.domain.funding.repository.FundingRepository;
@@ -74,6 +75,13 @@ public class FundingService {
     public Long delete(Long fundingId) {
         fundingRepository.deleteById(fundingId);
         return fundingId;
+    }
+
+    @Transactional(readOnly = true)
+    public List<FundingSummaryResponse> getFundingSummariesByMemberId(Long memberId) {
+        return fundingRepository.findByMemberIdOrderByCreatedAtDesc(memberId).stream()
+                .map(FundingSummaryResponse::toDto)
+                .toList();
     }
 
     @Scheduled(fixedRate = 60 * 1000) // 1분마다 실행

--- a/src/main/java/com/chaeum/api/domain/funding/service/FundingService.java
+++ b/src/main/java/com/chaeum/api/domain/funding/service/FundingService.java
@@ -8,7 +8,7 @@ import com.chaeum.api.domain.funding.entity.Funding;
 import com.chaeum.api.domain.funding.entity.FundingStatus;
 import com.chaeum.api.domain.funding.repository.FundingRepository;
 import com.chaeum.api.domain.member.entity.Member;
-import com.chaeum.api.domain.member.service.MemberService;
+import com.chaeum.api.global.auth.util.LoginMemberProvider;
 import com.chaeum.api.global.exception.ChaeumException;
 import com.chaeum.api.global.exception.ErrorCode;
 import com.chaeum.api.global.pagination.cursorResult.IdCursorResult;
@@ -26,11 +26,11 @@ import java.util.List;
 public class FundingService {
 
     private final FundingRepository fundingRepository;
-    private final MemberService memberService;
+    private final LoginMemberProvider loginMemberProvider;
 
     @Transactional
     public Long save(FundingCreateRequest fundingCreateRequest) {
-        Member member = memberService.getCurrentLoginMember();
+        Member member = loginMemberProvider.getCurrentLoginMember();
         Funding funding = Funding.toEntity(fundingCreateRequest, member);
         fundingRepository.save(funding);
         return funding.getId();

--- a/src/main/java/com/chaeum/api/domain/inventory/entity/Inventory.java
+++ b/src/main/java/com/chaeum/api/domain/inventory/entity/Inventory.java
@@ -49,12 +49,12 @@ public class Inventory extends BaseEntity {
     @Column(name = "quantity", nullable = false)
     private int quantity;
 
-    public static Inventory create(Item item, Member member) {
+    public static Inventory create(Item item, Member member, int quantity) {
         return Inventory.builder()
             .member(member)
             .item(item)
             .isWearing(false)
-            .quantity(1)
+            .quantity(quantity)
             .build();
     }
 

--- a/src/main/java/com/chaeum/api/domain/inventory/repository/InventoryRepository.java
+++ b/src/main/java/com/chaeum/api/domain/inventory/repository/InventoryRepository.java
@@ -14,4 +14,6 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
     List<Inventory> findByMemberIdAndIsWearing(Long memberId, boolean isWearing);
 
     Optional<Inventory> findByItemId(Long itemId);
+
+    boolean existsByMemberIdAndItemId(Long memberId, Long itemId);
 }

--- a/src/main/java/com/chaeum/api/domain/inventory/service/InventoryService.java
+++ b/src/main/java/com/chaeum/api/domain/inventory/service/InventoryService.java
@@ -9,15 +9,17 @@ import com.chaeum.api.domain.item.entity.Item;
 import com.chaeum.api.domain.item.entity.ItemCategory;
 import com.chaeum.api.domain.item.service.ItemService;
 import com.chaeum.api.domain.member.entity.Member;
-import com.chaeum.api.domain.member.service.MemberService;
+import com.chaeum.api.global.auth.util.LoginMemberProvider;
 import com.chaeum.api.global.exception.ChaeumException;
 import com.chaeum.api.global.exception.ErrorCode;
 import com.chaeum.api.global.pagination.cursorResult.CreatedAtCursorResult;
 import com.chaeum.api.global.utils.ExpConstants;
+
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,57 +29,60 @@ import org.springframework.transaction.annotation.Transactional;
 public class InventoryService {
 
     private final InventoryRepository inventoryRepository;
+    private final LoginMemberProvider loginMemberProvider;
     private final ItemService itemService;
-    private final MemberService memberService;
     private final CatService catService;
+
+    private static final int DEFAULT_ITEM_QUANTITY = 1;
+    private static final int DEFAULT_INTERACTION_ITEM_QUANTITY = 5;
 
     @Transactional
     public Long save(InventoryCreateRequest inventoryCreateRequest) {
         Long itemId = inventoryCreateRequest.getItemId();
         Item item = itemService.findById(itemId);
-        Member member = memberService.getCurrentLoginMember();
+        Member member = loginMemberProvider.getCurrentLoginMember();
 
         Inventory inventory = inventoryRepository.findByItemId(itemId)
-            .map(existingInventory -> {
-                existingInventory.addQuantity();
-                return existingInventory;
-            })
-            .orElseGet(() -> {
-                Inventory newInventory = Inventory.create(item, member);
-                inventoryRepository.save(newInventory);
-                return newInventory;
-            });
+                .map(existingInventory -> {
+                    existingInventory.addQuantity();
+                    return existingInventory;
+                })
+                .orElseGet(() -> {
+                    Inventory newInventory = Inventory.create(item, member, DEFAULT_ITEM_QUANTITY);
+                    inventoryRepository.save(newInventory);
+                    return newInventory;
+                });
 
         return inventory.getId();
     }
 
     @Transactional(readOnly = true)
     public CreatedAtCursorResult<InventoryResponse> getInventoriesByCategory(
-        ItemCategory category, LocalDateTime cursor, int limit
+            ItemCategory category, LocalDateTime cursor, int limit
     ) {
-        Long memberId = memberService.getCurrentLoginMemberId();
+        Long memberId = loginMemberProvider.getCurrentLoginMemberId();
         List<Inventory> inventories = findByMemberId(memberId);
 
         List<InventoryResponse> filteredInventories = inventories.stream()
-            .filter(inventory -> inventory.getItem().getCategory() == category)
-            .filter(inventory -> cursor == null || inventory.getCreatedAt().isAfter(cursor))
-            .sorted(Comparator.comparing(Inventory::getCreatedAt))
-            .map(InventoryResponse::toDto)
-            .collect(Collectors.toList());
+                .filter(inventory -> inventory.getItem().getCategory() == category)
+                .filter(inventory -> cursor == null || inventory.getCreatedAt().isAfter(cursor))
+                .sorted(Comparator.comparing(Inventory::getCreatedAt))
+                .map(InventoryResponse::toDto)
+                .collect(Collectors.toList());
 
         return CreatedAtCursorResult.of(filteredInventories, cursor, limit);
     }
 
     @Transactional(readOnly = true)
     public List<Long> getWearingInventoryItems() {
-        Long memberId = memberService.getCurrentLoginMemberId();
+        Long memberId = loginMemberProvider.getCurrentLoginMemberId();
         List<Inventory> inventories = inventoryRepository.findByMemberIdAndIsWearing(
-            memberId, true);
+                memberId, true);
         return inventories.stream()
-            .map(Inventory::getItem)
-            .filter(item -> item.isCategoryIn(ItemCategory.DECORATION, ItemCategory.INTERIOR))
-            .map(Item::getId)
-            .toList();
+                .map(Inventory::getItem)
+                .filter(item -> item.isCategoryIn(ItemCategory.DECORATION, ItemCategory.INTERIOR))
+                .map(Item::getId)
+                .toList();
     }
 
     @Transactional
@@ -106,9 +111,17 @@ public class InventoryService {
         catService.addExperience(ExpConstants.INTERACTION);
     }
 
+    @Transactional
+    public void registerDefaultInteractionItems(Member member) {
+        itemService.findByCategory(ItemCategory.INTERACTION).stream()
+                .filter(item -> !inventoryRepository.existsByMemberIdAndItemId(member.getId(), item.getId()))
+                .map(item -> Inventory.create(item, member, DEFAULT_INTERACTION_ITEM_QUANTITY))
+                .forEach(inventoryRepository::save);
+    }
+
     public Inventory findByInventoryId(Long inventoryId) {
         return inventoryRepository.findById(inventoryId)
-            .orElseThrow(() -> ChaeumException.from(ErrorCode.INVENTORY_NOT_FOUND));
+                .orElseThrow(() -> ChaeumException.from(ErrorCode.INVENTORY_NOT_FOUND));
     }
 
     public List<Inventory> findByMemberId(Long memberId) {

--- a/src/main/java/com/chaeum/api/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/chaeum/api/domain/item/repository/ItemRepository.java
@@ -1,9 +1,14 @@
 package com.chaeum.api.domain.item.repository;
 
 import com.chaeum.api.domain.item.entity.Item;
+import com.chaeum.api.domain.item.entity.ItemCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    List<Item> findByCategory(ItemCategory category);
 }

--- a/src/main/java/com/chaeum/api/domain/item/service/ItemService.java
+++ b/src/main/java/com/chaeum/api/domain/item/service/ItemService.java
@@ -67,6 +67,11 @@ public class ItemService {
         return itemId;
     }
 
+    @Transactional(readOnly = true)
+    public List<Item> findByCategory(ItemCategory category) {
+        return itemRepository.findByCategory(category);
+    }
+
     public Item findById(Long itemId) {
         return itemRepository.findById(itemId)
             .orElseThrow(() -> ChaeumException.from(ErrorCode.ITEM_NOT_FOUND));

--- a/src/main/java/com/chaeum/api/domain/member/controller/MemberController.java
+++ b/src/main/java/com/chaeum/api/domain/member/controller/MemberController.java
@@ -42,7 +42,7 @@ public class MemberController {
 
     @Operation(
             summary = "회원 수정",
-            description = "[모든 Role 가능] 회원 정보를 수정합니다."
+            description = "[모든 Role 가능] 회원의 이름과 프로필 이미지를 수정할 수 있습니다."
     )
     @PreAuthorize("hasRole('DONOR')")
     @PatchMapping("")
@@ -56,7 +56,7 @@ public class MemberController {
 
     @Operation(
             summary = "회원 삭제",
-            description = "[모든 Role 가능] 회원을 삭제합니다."
+            description = "[모든 Role 가능]"
     )
     @PreAuthorize("hasRole('DONOR')")
     @DeleteMapping("/{memberId}")

--- a/src/main/java/com/chaeum/api/domain/member/controller/MemberController.java
+++ b/src/main/java/com/chaeum/api/domain/member/controller/MemberController.java
@@ -1,16 +1,70 @@
 package com.chaeum.api.domain.member.controller;
 
+import com.chaeum.api.domain.member.dto.request.MemberUpdateRequest;
+import com.chaeum.api.domain.member.dto.response.MemberMyPageResponse;
 import com.chaeum.api.domain.member.service.MemberService;
+import com.chaeum.api.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/members")
+@RequestMapping("/api/v1/member")
 @RequiredArgsConstructor
 @Tag(name = "Member", description = "회원 관리")
 public class MemberController {
 
     private final MemberService memberService;
+
+    @Operation(
+            summary = "마이페이지",
+            description = """
+                    [모든 Role 가능]<br>
+                    기부자: 회원 정보와 누적 기부 금액, 기부 내역을 보여줍니다.<br>
+                    수혜자: 회원 정보와 진행 중인 펀딩 및 완료된 펀딩을 보여줍니다.
+                    """
+    )
+    @PreAuthorize("hasRole('DONOR')")
+    @GetMapping("")
+    public ApiResponse<MemberMyPageResponse> getMemberMyPage() {
+        Long memberId = memberService.getCurrentLoginMemberId();
+        return ApiResponse.success(memberService.getMemberMyPage(memberId));
+    }
+
+    @Operation(
+            summary = "회원 수정",
+            description = "[모든 Role 가능] 회원 정보를 수정합니다."
+    )
+    @PreAuthorize("hasRole('DONOR')")
+    @PatchMapping("")
+    public ApiResponse<Long> update(
+            @RequestParam(name = "memberId") Long memberId,
+            @Valid @RequestBody MemberUpdateRequest memberUpdateRequest
+    ) {
+        Long id = memberService.update(memberId, memberUpdateRequest);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(
+            summary = "회원 삭제",
+            description = "[모든 Role 가능] 회원을 삭제합니다."
+    )
+    @PreAuthorize("hasRole('DONOR')")
+    @DeleteMapping("/{memberId}")
+    public ApiResponse<Long> delete(
+            @PathVariable(name = "memberId") Long memberId
+    ) {
+        Long id = memberService.delete(memberId);
+        return ApiResponse.success(id);
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/member/controller/MemberController.java
+++ b/src/main/java/com/chaeum/api/domain/member/controller/MemberController.java
@@ -37,8 +37,7 @@ public class MemberController {
     @PreAuthorize("hasRole('DONOR')")
     @GetMapping("")
     public ApiResponse<MemberMyPageResponse> getMemberMyPage() {
-        Long memberId = memberService.getCurrentLoginMemberId();
-        return ApiResponse.success(memberService.getMemberMyPage(memberId));
+        return ApiResponse.success(memberService.getMemberMyPage());
     }
 
     @Operation(

--- a/src/main/java/com/chaeum/api/domain/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/member/dto/request/MemberUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.chaeum.api.domain.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberUpdateRequest {
+
+    @NotNull
+    @Schema(description = "이름", example = "김민상")
+    private String name;
+
+    @NotNull
+    @Schema(description = "프로필 이미지 URL", example = "https://chaeum.site/image.png")
+    private String profileImage;
+}

--- a/src/main/java/com/chaeum/api/domain/member/dto/response/BeneficiaryMyPageResponse.java
+++ b/src/main/java/com/chaeum/api/domain/member/dto/response/BeneficiaryMyPageResponse.java
@@ -1,0 +1,30 @@
+package com.chaeum.api.domain.member.dto.response;
+
+import com.chaeum.api.domain.funding.dto.response.FundingSummaryResponse;
+import com.chaeum.api.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class BeneficiaryMyPageResponse implements MemberMyPageResponse {
+
+    private String name;
+
+    private String email;
+
+    private String profileImage;
+
+    private List<FundingSummaryResponse> fundings;
+
+    public static BeneficiaryMyPageResponse toDto(Member member, List<FundingSummaryResponse> fundings) {
+        return BeneficiaryMyPageResponse.builder()
+                .name(member.getName())
+                .email(member.getEmail())
+                .profileImage(member.getProfileImage())
+                .fundings(fundings)
+                .build();
+    }
+}

--- a/src/main/java/com/chaeum/api/domain/member/dto/response/DonorMyPageResponse.java
+++ b/src/main/java/com/chaeum/api/domain/member/dto/response/DonorMyPageResponse.java
@@ -34,6 +34,8 @@ public class DonorMyPageResponse implements MemberMyPageResponse {
                 .name(member.getName())
                 .email(member.getEmail())
                 .profileImage(member.getProfileImage())
+                .monthlyAmount(monthlyAmount)
+                .yearlyAmount(yearlyAmount)
                 .donations(donations)
                 .build();
     }

--- a/src/main/java/com/chaeum/api/domain/member/dto/response/DonorMyPageResponse.java
+++ b/src/main/java/com/chaeum/api/domain/member/dto/response/DonorMyPageResponse.java
@@ -1,0 +1,40 @@
+package com.chaeum.api.domain.member.dto.response;
+
+import com.chaeum.api.domain.donation.dto.response.DonationSummaryResponse;
+import com.chaeum.api.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Builder
+public class DonorMyPageResponse implements MemberMyPageResponse {
+
+    private String name;
+
+    private String email;
+
+    private String profileImage;
+
+    private BigDecimal monthlyAmount;
+
+    private BigDecimal yearlyAmount;
+
+    private List<DonationSummaryResponse> donations;
+
+    public static DonorMyPageResponse toDto(
+            Member member,
+            BigDecimal monthlyAmount,
+            BigDecimal yearlyAmount,
+            List<DonationSummaryResponse> donations
+    ) {
+        return DonorMyPageResponse.builder()
+                .name(member.getName())
+                .email(member.getEmail())
+                .profileImage(member.getProfileImage())
+                .donations(donations)
+                .build();
+    }
+}

--- a/src/main/java/com/chaeum/api/domain/member/dto/response/MemberMyPageResponse.java
+++ b/src/main/java/com/chaeum/api/domain/member/dto/response/MemberMyPageResponse.java
@@ -1,0 +1,5 @@
+package com.chaeum.api.domain.member.dto.response;
+
+public interface MemberMyPageResponse {
+
+}

--- a/src/main/java/com/chaeum/api/domain/member/entity/Member.java
+++ b/src/main/java/com/chaeum/api/domain/member/entity/Member.java
@@ -1,14 +1,10 @@
 package com.chaeum.api.domain.member.entity;
 
-import com.chaeum.api.domain.attendance.entity.Attendance;
 import com.chaeum.api.domain.cat.entity.Cat;
 import com.chaeum.api.domain.donation.entity.Donation;
-import com.chaeum.api.domain.friendship.entity.Friendship;
 import com.chaeum.api.domain.inventory.entity.Inventory;
-import com.chaeum.api.domain.missionProgress.entity.MissionProgress;
+import com.chaeum.api.domain.member.dto.request.MemberUpdateRequest;
 import com.chaeum.api.domain.paymentRecord.entity.PaymentRecord;
-import com.chaeum.api.domain.review.entity.Review;
-import com.chaeum.api.domain.title.entity.Title;
 import com.chaeum.api.global.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -29,6 +25,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
+import java.util.Optional;
 
 @Entity
 @Getter
@@ -79,21 +76,26 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Donation> donations;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MissionProgress> missionProgresses;
+//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<MissionProgress> missionProgresses;
+//
+//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Friendship> friendships;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Friendship> friendships;
+//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Attendance> attendances;
+//
+//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Title> titles;
+//
+//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Notification> notifications;
+//
+//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Review> reviews;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Attendance> attendances;
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Title> titles;
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Notification> notifications;
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Review> reviews;
+    public void update(MemberUpdateRequest memberUpdateRequest) {
+        Optional.ofNullable(memberUpdateRequest.getName()).ifPresent(this::setName);
+        Optional.ofNullable(memberUpdateRequest.getProfileImage()).ifPresent(this::setProfileImage);
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/member/entity/Member.java
+++ b/src/main/java/com/chaeum/api/domain/member/entity/Member.java
@@ -1,6 +1,16 @@
 package com.chaeum.api.domain.member.entity;
 
+import com.chaeum.api.domain.attendance.entity.Attendance;
+import com.chaeum.api.domain.cat.entity.Cat;
+import com.chaeum.api.domain.donation.entity.Donation;
+import com.chaeum.api.domain.friendship.entity.Friendship;
+import com.chaeum.api.domain.inventory.entity.Inventory;
+import com.chaeum.api.domain.missionProgress.entity.MissionProgress;
+import com.chaeum.api.domain.paymentRecord.entity.PaymentRecord;
+import com.chaeum.api.domain.review.entity.Review;
+import com.chaeum.api.domain.title.entity.Title;
 import com.chaeum.api.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -8,6 +18,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -15,6 +27,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -27,48 +41,59 @@ public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
     private Long id;
 
+    @Column(name = "name")
     private String name;
 
-    @Column(nullable = false, unique = true)
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(name = "role", nullable = false)
     private Role role;
 
-    @Column(nullable = false)
-    private boolean isBeneficiary = false;
+    @Column(name = "is_beneficiary", nullable = false)
+    private Boolean isBeneficiary = Boolean.FALSE;
 
+    @Column(name = "profile_image")
     private String profileImage;
 
+    @Column(name = "points")
     private int points;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "social_login_type")
     private SocialLoginType socialLoginType;
 
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Cat> cats;
-//
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Inventory> inventoryItems;
-//
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Title> titles;
-//
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Attendance> attendanceRecords;
-//
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<MissionProgress> missionProgressList;
-//
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Donation> donations;
-//
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Payment> payments;
-//
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Friendship> friendships;
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Cat cat;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Inventory> inventoryItems;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PaymentRecord> payments;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Donation> donations;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MissionProgress> missionProgresses;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Friendship> friendships;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Attendance> attendances;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Title> titles;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Notification> notifications;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> reviews;
 }

--- a/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
@@ -40,7 +40,7 @@ public class MemberService {
         if (principal instanceof CustomMemberDetails customMemberDetails) {
             return customMemberDetails.getMember();
         }
-        throw ChaeumException.from(ErrorCode.UNAUTHORIZED);
+        throw ChaeumException.from(ErrorCode.MEMBER_NOT_FOUND);
     }
 
     public Long getCurrentLoginMemberId() {

--- a/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
@@ -1,10 +1,9 @@
 package com.chaeum.api.domain.member.service;
 
 import com.chaeum.api.domain.donation.dto.response.DonationSummaryResponse;
-import com.chaeum.api.domain.donation.repository.DonationRepository;
 import com.chaeum.api.domain.donation.service.DonationService;
 import com.chaeum.api.domain.funding.dto.response.FundingSummaryResponse;
-import com.chaeum.api.domain.funding.repository.FundingRepository;
+import com.chaeum.api.domain.funding.service.FundingService;
 import com.chaeum.api.domain.member.dto.request.MemberUpdateRequest;
 import com.chaeum.api.domain.member.dto.response.BeneficiaryMyPageResponse;
 import com.chaeum.api.domain.member.dto.response.DonorMyPageResponse;
@@ -29,8 +28,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final DonationService donationService;
-    private final DonationRepository donationRepository;
-    private final FundingRepository fundingRepository;
+    private final FundingService fundingService;
 
     public Member getCurrentLoginMember() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -53,21 +51,14 @@ public class MemberService {
     public MemberMyPageResponse getMemberMyPage() {
         Member member = getCurrentLoginMember();
         Long memberId = member.getId();
-        if (member.getIsBeneficiary()) {
-            // 수혜자 마이페이지
-            List<FundingSummaryResponse> fundings = fundingRepository
-                    .findByMemberIdOrderByCreatedAtDesc(memberId).stream()
-                    .map(FundingSummaryResponse::toDto)
-                    .toList();
+
+        if (member.getIsBeneficiary()) { // 수혜자 마이페이지
+            List<FundingSummaryResponse> fundings = fundingService.getFundingSummariesByMemberId(memberId);
             return BeneficiaryMyPageResponse.toDto(member, fundings);
-        } else {
-            // 기부자 마이페이지
+        } else { // 기부자 마이페이지
             BigDecimal monthlyAmount = donationService.getThisMonthTotalByMemberId(memberId);
             BigDecimal yearlyAmount = donationService.getThisYearTotalByMemberId(memberId);
-            List<DonationSummaryResponse> donations = donationRepository
-                    .findByMemberIdOrderByCreatedAtDesc(memberId).stream()
-                    .map(DonationSummaryResponse::toDto)
-                    .toList();
+            List<DonationSummaryResponse> donations = donationService.getDonationSummariesByMemberId(memberId);
             return DonorMyPageResponse.toDto(member, monthlyAmount, yearlyAmount, donations);
         }
     }

--- a/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
@@ -50,17 +50,7 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MemberMyPageResponse getMemberMyPage() {
         Member member = getCurrentLoginMember();
-        Long memberId = member.getId();
-
-        if (member.getIsBeneficiary()) { // 수혜자 마이페이지
-            List<FundingSummaryResponse> fundings = fundingService.getFundingSummariesByMemberId(memberId);
-            return BeneficiaryMyPageResponse.toDto(member, fundings);
-        } else { // 기부자 마이페이지
-            BigDecimal monthlyAmount = donationService.getThisMonthTotalByMemberId(memberId);
-            BigDecimal yearlyAmount = donationService.getThisYearTotalByMemberId(memberId);
-            List<DonationSummaryResponse> donations = donationService.getDonationSummariesByMemberId(memberId);
-            return DonorMyPageResponse.toDto(member, monthlyAmount, yearlyAmount, donations);
-        }
+        return member.getIsBeneficiary() ? getBeneficiaryMyPage(member) : getDonorMyPage(member);
     }
 
     @Transactional
@@ -74,6 +64,19 @@ public class MemberService {
     public Long delete(Long memberId) {
         memberRepository.deleteById(memberId);
         return memberId;
+    }
+
+    private MemberMyPageResponse getBeneficiaryMyPage(Member member) {
+        List<FundingSummaryResponse> fundings = fundingService.getFundingSummariesByMemberId(member.getId());
+        return BeneficiaryMyPageResponse.toDto(member, fundings);
+    }
+
+    private MemberMyPageResponse getDonorMyPage(Member member) {
+        Long memberId = member.getId();
+        BigDecimal monthlyAmount = donationService.getThisMonthTotalByMemberId(memberId);
+        BigDecimal yearlyAmount = donationService.getThisYearTotalByMemberId(memberId);
+        List<DonationSummaryResponse> donations = donationService.getDonationSummariesByMemberId(memberId);
+        return DonorMyPageResponse.toDto(member, monthlyAmount, yearlyAmount, donations);
     }
 
     private Member findById(Long memberId) {

--- a/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
@@ -10,12 +10,10 @@ import com.chaeum.api.domain.member.dto.response.DonorMyPageResponse;
 import com.chaeum.api.domain.member.dto.response.MemberMyPageResponse;
 import com.chaeum.api.domain.member.entity.Member;
 import com.chaeum.api.domain.member.repository.MemberRepository;
-import com.chaeum.api.global.auth.dto.CustomMemberDetails;
+import com.chaeum.api.global.auth.util.LoginMemberProvider;
 import com.chaeum.api.global.exception.ChaeumException;
 import com.chaeum.api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,27 +27,11 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final DonationService donationService;
     private final FundingService fundingService;
-
-    public Member getCurrentLoginMember() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw ChaeumException.from(ErrorCode.UNAUTHORIZED);
-        }
-
-        Object principal = authentication.getPrincipal();
-        if (principal instanceof CustomMemberDetails customMemberDetails) {
-            return customMemberDetails.getMember();
-        }
-        throw ChaeumException.from(ErrorCode.MEMBER_NOT_FOUND);
-    }
-
-    public Long getCurrentLoginMemberId() {
-        return getCurrentLoginMember().getId();
-    }
+    private final LoginMemberProvider loginMemberProvider;
 
     @Transactional(readOnly = true)
     public MemberMyPageResponse getMemberMyPage() {
-        Member member = getCurrentLoginMember();
+        Member member = loginMemberProvider.getCurrentLoginMember();
         return member.getIsBeneficiary() ? getBeneficiaryMyPage(member) : getDonorMyPage(member);
     }
 

--- a/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
@@ -1,34 +1,91 @@
 package com.chaeum.api.domain.member.service;
 
+import com.chaeum.api.domain.donation.dto.response.DonationSummaryResponse;
+import com.chaeum.api.domain.donation.repository.DonationRepository;
+import com.chaeum.api.domain.donation.service.DonationService;
+import com.chaeum.api.domain.funding.dto.response.FundingSummaryResponse;
+import com.chaeum.api.domain.funding.repository.FundingRepository;
+import com.chaeum.api.domain.member.dto.request.MemberUpdateRequest;
+import com.chaeum.api.domain.member.dto.response.BeneficiaryMyPageResponse;
+import com.chaeum.api.domain.member.dto.response.DonorMyPageResponse;
+import com.chaeum.api.domain.member.dto.response.MemberMyPageResponse;
 import com.chaeum.api.domain.member.entity.Member;
 import com.chaeum.api.domain.member.repository.MemberRepository;
 import com.chaeum.api.global.auth.dto.CustomMemberDetails;
+import com.chaeum.api.global.exception.ChaeumException;
+import com.chaeum.api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final DonationService donationService;
+    private final DonationRepository donationRepository;
+    private final FundingRepository fundingRepository;
 
     public Member getCurrentLoginMember() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
-            return null;
+            throw ChaeumException.from(ErrorCode.UNAUTHORIZED);
         }
+
         Object principal = authentication.getPrincipal();
-        if (principal instanceof CustomMemberDetails) {
-            return ((CustomMemberDetails) principal).getMember();
-        } else {
-            return null;
+        if (principal instanceof CustomMemberDetails customMemberDetails) {
+            return customMemberDetails.getMember();
         }
+        throw ChaeumException.from(ErrorCode.UNAUTHORIZED);
     }
 
     public Long getCurrentLoginMemberId() {
-        Member member = getCurrentLoginMember();
-        return member != null ? member.getId() : null;
+        return getCurrentLoginMember().getId();
+    }
+
+    @Transactional(readOnly = true)
+    public MemberMyPageResponse getMemberMyPage(Long memberId) {
+        Member member = findById(memberId);
+        if (member.getIsBeneficiary()) {
+            // 수혜자 마이페이지
+            List<FundingSummaryResponse> fundings = fundingRepository
+                    .findByMemberIdOrderByCreatedAtDesc(memberId).stream()
+                    .map(FundingSummaryResponse::toDto)
+                    .toList();
+            return BeneficiaryMyPageResponse.toDto(member, fundings);
+        } else {
+            // 기부자 마이페이지
+            BigDecimal monthlyAmount = donationService.getThisMonthTotalByMemberId(memberId);
+            BigDecimal yearlyAmount = donationService.getThisYearTotalByMemberId(memberId);
+            List<DonationSummaryResponse> donations = donationRepository
+                    .findByMemberIdOrderByCreatedAtDesc(memberId).stream()
+                    .map(DonationSummaryResponse::toDto)
+                    .toList();
+            return DonorMyPageResponse.toDto(member, monthlyAmount, yearlyAmount, donations);
+        }
+    }
+
+    @Transactional
+    public Long update(Long memberId, MemberUpdateRequest memberUpdateRequest) {
+        Member member = findById(memberId);
+        member.update(memberUpdateRequest);
+        return member.getId();
+    }
+
+    @Transactional
+    public Long delete(Long memberId) {
+        memberRepository.deleteById(memberId);
+        return memberId;
+    }
+
+    private Member findById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> ChaeumException.from(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
@@ -50,8 +50,9 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberMyPageResponse getMemberMyPage(Long memberId) {
-        Member member = findById(memberId);
+    public MemberMyPageResponse getMemberMyPage() {
+        Member member = getCurrentLoginMember();
+        Long memberId = member.getId();
         if (member.getIsBeneficiary()) {
             // 수혜자 마이페이지
             List<FundingSummaryResponse> fundings = fundingRepository

--- a/src/main/java/com/chaeum/api/domain/missionProgress/entity/MissionProgress.java
+++ b/src/main/java/com/chaeum/api/domain/missionProgress/entity/MissionProgress.java
@@ -1,4 +1,27 @@
 package com.chaeum.api.domain.missionProgress.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "mission_progress")
 public class MissionProgress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 }

--- a/src/main/java/com/chaeum/api/domain/paymentRecord/service/PaymentRecordService.java
+++ b/src/main/java/com/chaeum/api/domain/paymentRecord/service/PaymentRecordService.java
@@ -1,7 +1,6 @@
 package com.chaeum.api.domain.paymentRecord.service;
 
 import com.chaeum.api.domain.member.entity.Member;
-import com.chaeum.api.domain.member.service.MemberService;
 import com.chaeum.api.domain.paymentRecord.dto.request.PaymentCreateRequest;
 import com.chaeum.api.domain.paymentRecord.dto.response.PaymentResponse;
 import com.chaeum.api.domain.paymentRecord.entity.PaymentRecord;
@@ -9,6 +8,7 @@ import com.chaeum.api.domain.paymentRecord.entity.PaymentGatewayInfo;
 import com.chaeum.api.domain.paymentRecord.entity.PaymentMethod;
 import com.chaeum.api.domain.paymentRecord.entity.PaymentStatus;
 import com.chaeum.api.domain.paymentRecord.repository.PaymentRecordRepository;
+import com.chaeum.api.global.auth.util.LoginMemberProvider;
 import com.chaeum.api.global.exception.ChaeumException;
 import com.chaeum.api.global.exception.ErrorCode;
 import com.siot.IamportRestClient.IamportClient;
@@ -31,7 +31,7 @@ import java.util.List;
 public class PaymentRecordService {
 
     private final PaymentRecordRepository paymentRecordRepository;
-    private final MemberService memberService;
+    private final LoginMemberProvider loginMemberProvider;
     private final IamportClient iamportClient;
 
     @Transactional
@@ -77,7 +77,7 @@ public class PaymentRecordService {
         Payment iamportPayment = fetchAndValidateIamportPayment(paymentCreateRequest);
         log.info("[결제 생성] 결제 검증 완료 - 결제 상태: {}, 결제 금액: {}", iamportPayment.getStatus(), iamportPayment.getAmount());
 
-        Member member = memberService.getCurrentLoginMember();
+        Member member = loginMemberProvider.getCurrentLoginMember();
         PaymentGatewayInfo paymentGatewayInfo = PaymentGatewayInfo.create(paymentCreateRequest.getPaymentGatewayInfoRequest());
 
         PaymentRecord paymentRecord = PaymentRecord.create(member, paymentCreateRequest, paymentGatewayInfo);

--- a/src/main/java/com/chaeum/api/domain/title/entity/Title.java
+++ b/src/main/java/com/chaeum/api/domain/title/entity/Title.java
@@ -1,4 +1,27 @@
 package com.chaeum.api.domain.title.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "title")
 public class Title {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 }

--- a/src/main/java/com/chaeum/api/global/auth/service/CustomOAuth2MemberService.java
+++ b/src/main/java/com/chaeum/api/global/auth/service/CustomOAuth2MemberService.java
@@ -74,6 +74,7 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
                 .email(oAuth2Response.getEmail())
                 .name(oAuth2Response.getName())
                 .role(Role.DONOR)
+                .isBeneficiary(Boolean.FALSE)
                 .socialLoginType(SocialLoginType.from(oAuth2Response.getProvider()))
                 .build();
         return memberRepository.save(newMember);

--- a/src/main/java/com/chaeum/api/global/auth/service/CustomOAuth2MemberService.java
+++ b/src/main/java/com/chaeum/api/global/auth/service/CustomOAuth2MemberService.java
@@ -1,5 +1,7 @@
 package com.chaeum.api.global.auth.service;
 
+import com.chaeum.api.domain.cat.service.CatService;
+import com.chaeum.api.domain.inventory.service.InventoryService;
 import com.chaeum.api.domain.member.entity.Member;
 import com.chaeum.api.domain.member.entity.Role;
 import com.chaeum.api.domain.member.entity.SocialLoginType;
@@ -12,30 +14,24 @@ import com.chaeum.api.global.auth.dto.OAuth2Response;
 import com.chaeum.api.global.exception.ChaeumException;
 import com.chaeum.api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
 
     private final MemberRepository memberRepository;
+    private final CatService catService;
+    private final InventoryService inventoryService;
 
-    // OAuth2 제공자로부터 사용자 정보를 가져와 처리
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
-
-        // 1. OAuth2 제공자 판별 (naver, kakao)
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-
-        log.info("OAuth2 Provider: {}", registrationId);
-        log.info("OAuth2User Attributes: {}", oAuth2User.getAttributes());
 
         OAuth2Response oAuth2Response = switch (registrationId) {
             case "naver" -> new NaverResponse(oAuth2User.getAttributes());
@@ -43,40 +39,40 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
             default -> throw ChaeumException.from(ErrorCode.UNSUPPORTED_OAUTH2_PROVIDER);
         };
 
-
-        log.info(oAuth2Response.getProviderId(), oAuth2Response.getProvider(), oAuth2Response.getName(), oAuth2Response.getEmail());
-
-        // 2. 기존 회원 조회 및 존재 여부 확인 (존재: 이름 갱신, 없음: 새로 생성)
         Member member = memberRepository.findByEmail(oAuth2Response.getEmail())
-                .map(existingMember -> updateMemberName(existingMember, oAuth2Response.getName()))
+                .map(existingMember -> updateMember(existingMember, oAuth2Response.getName()))
                 .orElseGet(() -> joinMember(oAuth2Response));
 
-        log.info("OAuth2 로그인 요청: {}", oAuth2Response.getEmail());
-
-        // 3. OAuth2Member 인가된 정보 반환
         OAuth2MemberDto oAuth2MemberDto = new OAuth2MemberDto(member.getEmail(), member.getName(), member.getProfileImage());
         return new CustomOAuth2Member(oAuth2MemberDto, memberRepository);
     }
 
-    // 기존 회원의 이름을 업데이트하고 저장
-    private Member updateMemberName(Member member, String newName) {
+    private Member joinMember(OAuth2Response oAuth2Response) {
+        Member member = memberRepository.save(createMemberForm(oAuth2Response));
+        initNewMember(member);
+        return member;
+    }
+
+    private Member createMemberForm(OAuth2Response oAuth2Response) {
+        return Member.builder()
+                .email(oAuth2Response.getEmail())
+                .name(oAuth2Response.getName())
+                .role(Role.DONOR)
+                .isBeneficiary(false)
+                .socialLoginType(SocialLoginType.from(oAuth2Response.getProvider()))
+                .build();
+    }
+
+    private void initNewMember(Member member) {
+        catService.registerCatForMember(member);
+        inventoryService.registerDefaultInteractionItems(member);
+    }
+
+    private Member updateMember(Member member, String newName) {
         member.setName(newName);
-        // 기존 회원의 역할이 null이면 기본값 설정
         if (member.getRole() == null) {
             member.setRole(Role.DONOR);
         }
         return memberRepository.save(member);
-    }
-
-    // 새로운 회원을 생성하고 저장
-    private Member joinMember(OAuth2Response oAuth2Response) {
-        Member newMember = Member.builder()
-                .email(oAuth2Response.getEmail())
-                .name(oAuth2Response.getName())
-                .role(Role.DONOR)
-                .isBeneficiary(Boolean.FALSE)
-                .socialLoginType(SocialLoginType.from(oAuth2Response.getProvider()))
-                .build();
-        return memberRepository.save(newMember);
     }
 }

--- a/src/main/java/com/chaeum/api/global/auth/util/LoginMemberProvider.java
+++ b/src/main/java/com/chaeum/api/global/auth/util/LoginMemberProvider.java
@@ -1,0 +1,32 @@
+package com.chaeum.api.global.auth.util;
+
+import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.global.auth.dto.CustomMemberDetails;
+import com.chaeum.api.global.exception.ChaeumException;
+import com.chaeum.api.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LoginMemberProvider {
+
+    public Member getCurrentLoginMember() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw ChaeumException.from(ErrorCode.UNAUTHORIZED);
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof CustomMemberDetails customMemberDetails) {
+            return customMemberDetails.getMember();
+        }
+        throw ChaeumException.from(ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    public Long getCurrentLoginMemberId() {
+        return getCurrentLoginMember().getId();
+    }
+}


### PR DESCRIPTION
## ⭐️ Overview

> #71 

회원 기능 API를 구현했습니다.

## 🔧 Tasks

- 회원 생성 시 상호작용 아이템 기본 5개 추가 및 고양이 초기화
- 기부자용 마이페이지(월별/연도별 기부 총합)
- 수혜자용 마이페이지(펀딩 내역)
- 회원 수정
- 회원 삭제

- 월별 / 연도별 기부 내역 조회
- Member와 연관된 Donation / Funding 매핑
- 회원가입 시 수혜자 확인 필드 초기화

- 현재 로그인된 회원조회 로직 분리(순환 오류 해결)

## 📝 Additional Notes

- 마이페이지 API 호출 시 공통 응답 타입인 `MemberMyPageResponse` 인터페이스를 반환합니다.
  실제 응답은 기부자용 DTO(`DonorMyPageResponse`) 또는 수혜자용 DTO(`BeneficiaryMyPageResponse`)로 분기됩니다.
  서비스 단에서 `member.getIsBeneficiary()` 조건으로 분기하여 각각의 응답 DTO를 매핑했습니다.

- 수혜자 테스트는 '김민상' 계정의 Role을 수동으로 `RECIPIENT`로 변경 후 진행했습니다.
- 테스트 중 `isBeneficiary` 필드 초기화가 누락되어 회원 생성이 되지 않는 이슈를 발견하고 기본값을 설정하여 해결하였습니다.

- 현재 로그인한 회원 조회 로직을 `LoginMemberProvider`로 분리하여 /global/auth 폴더로 이동하고, 순환 참조 오류를 해결했습니다.

- 혹시 구조적으로 더 나은 설계 방향이 있다면 피드백 주시면 감사하겠습니다!

## 📸 Screenshot
<h3>💰 기부자 - 초기 마이페이지</h3>
<img width="400" alt="기부자 초기 마이페이지" src="https://github.com/user-attachments/assets/a480e710-6f12-43f4-bf86-e70a1c12481b" />

<h3>💰 기부자 - 기부금액 포함 마이페이지</h3>
<img width="400" alt="기부자 기부금액 포함" src="https://github.com/user-attachments/assets/112eff93-e4f5-4073-933d-002cdeeb4a7e" />

<h3>🎁 수혜자 - 마이페이지</h3>
<img width="400" alt="수혜자 마이페이지" src="https://github.com/user-attachments/assets/eada0293-b1d6-49de-ad54-fcc3f1a998dc" />

<h3>🐱 인벤토리 및 고양이 초기화 화면 (회원 생성 시)</h3>
<div style="display: flex; gap: 12px; margin-top: 8px;">
  <img width="330" alt="고양이 인벤토리 초기화 1" src="https://github.com/user-attachments/assets/3a71ac79-eb9d-4fbe-b69e-053f2820ac08" />
  <img width="400" alt="고양이 인벤토리 초기화 2" src="https://github.com/user-attachments/assets/85c55dc1-f6af-4074-ac27-f27dba566588" />
</div>