### PR TITLE
feat: 친구 기능 API 구현

### DIFF
--- a/src/main/java/com/chaeum/api/domain/donation/repository/DonationRepository.java
+++ b/src/main/java/com/chaeum/api/domain/donation/repository/DonationRepository.java
@@ -14,15 +14,25 @@ public interface DonationRepository extends JpaRepository<Donation, Long> {
     List<Donation> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 
     @Query(value = "SELECT * FROM donation d " +
-            "WHERE d.member_id = :memberId " +
-            "AND EXTRACT(YEAR FROM d.created_at) = :year " +
-            "AND EXTRACT(MONTH FROM d.created_at) = :month",
-            nativeQuery = true)
-    List<Donation> findByMemberIdAndYearAndMonth(@Param("memberId") Long memberId, @Param("year") int year, @Param("month") int month);
+        "WHERE d.member_id = :memberId " +
+        "AND EXTRACT(YEAR FROM d.created_at) = :year " +
+        "AND EXTRACT(MONTH FROM d.created_at) = :month",
+        nativeQuery = true)
+    List<Donation> findByMemberIdAndYearAndMonth(@Param("memberId") Long memberId, @Param("year") int year,
+        @Param("month") int month);
 
     @Query(value = "SELECT * FROM donation d " +
-            "WHERE d.member_id = :memberId " +
-            "AND EXTRACT(YEAR FROM d.created_at) = :year",
-            nativeQuery = true)
+        "WHERE d.member_id = :memberId " +
+        "AND EXTRACT(YEAR FROM d.created_at) = :year",
+        nativeQuery = true)
     List<Donation> findByMemberIdAndYear(@Param("memberId") Long memberId, @Param("year") int year);
+
+    @Query("""
+            SELECT COUNT(DISTINCT d1.funding.id)
+            FROM Donation d1
+            JOIN Donation d2 ON d1.funding.id = d2.funding.id
+            WHERE d1.member.id = :memberA
+              AND d2.member.id = :memberB
+        """)
+    int countSameFundingDonations(@Param("memberA") Long memberA, @Param("memberB") Long memberB);
 }

--- a/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
+++ b/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
@@ -3,6 +3,7 @@ package com.chaeum.api.domain.donation.service;
 import com.chaeum.api.domain.donation.dto.response.DonationSummaryResponse;
 import com.chaeum.api.domain.donation.entity.Donation;
 import com.chaeum.api.domain.donation.repository.DonationRepository;
+import com.chaeum.api.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,8 +25,8 @@ public class DonationService {
         int currentMonth = now.getMonthValue();
 
         return donationRepository.findByMemberIdAndYearAndMonth(memberId, currentYear, currentMonth).stream()
-                .map(Donation::getAmount)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+            .map(Donation::getAmount)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     @Transactional(readOnly = true)
@@ -33,14 +34,19 @@ public class DonationService {
         int currentYear = LocalDateTime.now().getYear();
 
         return donationRepository.findByMemberIdAndYear(memberId, currentYear).stream()
-                .map(Donation::getAmount)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+            .map(Donation::getAmount)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     @Transactional(readOnly = true)
     public List<DonationSummaryResponse> getDonationSummariesByMemberId(Long memberId) {
         return donationRepository.findByMemberIdOrderByCreatedAtDesc(memberId).stream()
-                .map(DonationSummaryResponse::toDto)
-                .toList();
+            .map(DonationSummaryResponse::toDto)
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public int getCountSharedDonations(Member member1, Member member2) {
+        return donationRepository.countSameFundingDonations(member1.getId(), member2.getId());
     }
 }

--- a/src/main/java/com/chaeum/api/domain/friendship/controller/FriendshipController.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/controller/FriendshipController.java
@@ -1,4 +1,90 @@
 package com.chaeum.api.domain.friendship.controller;
 
+import com.chaeum.api.domain.friendship.dto.request.FriendshipCreateRequest;
+import com.chaeum.api.domain.friendship.dto.request.FriendshipUpdateRequest;
+import com.chaeum.api.domain.friendship.dto.response.FriendshipResponse;
+import com.chaeum.api.domain.friendship.service.FriendshipService;
+import com.chaeum.api.global.pagination.cursorResult.IdCursorResult;
+import com.chaeum.api.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/friendship")
+@RequiredArgsConstructor
+@Tag(name = "Friendship", description = "친구 관리")
 public class FriendshipController {
+
+    private final FriendshipService friendshipService;
+
+    @Operation(summary = "친구 등록", description = "[모든 Role 가능]")
+    @PreAuthorize("hasRole('DONOR')")
+    @PostMapping("")
+    public ApiResponse<Long> save(
+        @Valid @RequestBody FriendshipCreateRequest friendshipCreateRequest
+    ) {
+        Long id = friendshipService.save(friendshipCreateRequest);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(summary = "친구 개별 조회", description = "[모든 Role 가능]")
+    @PreAuthorize("hasRole('DONOR')")
+    @GetMapping("")
+    public ApiResponse<FriendshipResponse> getFriend(
+        @RequestParam(name = "friendshipId") Long friendshipId
+    ) {
+        FriendshipResponse friendshipResponse = friendshipService.getFriend(friendshipId);
+        return ApiResponse.success(friendshipResponse);
+    }
+
+    @Operation(
+        summary = "조건별 친구 조회",
+        description = """
+            [모든 Role 조회 가능]<br>
+            이름을 입력하지 않으면 전체 조회됨<br>
+            """
+    )
+    @PreAuthorize("hasRole('DONOR')")
+    @GetMapping("/condition")
+    public ApiResponse<IdCursorResult<FriendshipResponse>> getFriendsByCondition(
+        @RequestParam(name = "friendName", required = false) String friendName,
+        @RequestParam(name = "cursor", required = false) Long cursor,
+        @RequestParam(name = "limit", defaultValue = "6") int limit
+    ) {
+        IdCursorResult<FriendshipResponse> friendships =
+            friendshipService.getFriendshipsByCondition(friendName, cursor, limit);
+        return ApiResponse.success(friendships);
+    }
+
+    @Operation(summary = "친구 요청 상태 변경", description = "친구 요청 수락, 거절 등")
+    @PreAuthorize("hasRole('DONOR')")
+    @PatchMapping("")
+    public ApiResponse<Long> updateFriendshipStatus(
+        @Valid @RequestBody FriendshipUpdateRequest friendshipUpdateRequest
+    ) {
+        Long id = friendshipService.update(friendshipUpdateRequest);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(summary = "친구 삭제", description = "[모든 Role 가능]")
+    @PreAuthorize("hasRole('DONOR')")
+    @DeleteMapping("/{friendshipId}")
+    public ApiResponse<Long> delete(
+        @PathVariable Long friendshipId
+    ) {
+        Long id = friendshipService.delete(friendshipId);
+        return ApiResponse.success(id);
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/friendship/controller/FriendshipController.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/controller/FriendshipController.java
@@ -63,14 +63,14 @@ public class FriendshipController {
             """
     )
     @PreAuthorize("hasRole('DONOR')")
-    @GetMapping("/condition")
-    public ApiResponse<IdCursorResult<FriendshipResponse>> getFriendsByCondition(
+    @GetMapping("/name")
+    public ApiResponse<IdCursorResult<FriendshipResponse>> getFriendsByName(
         @RequestParam(name = "friendName", required = false) String friendName,
         @RequestParam(name = "cursor", required = false) Long cursor,
         @RequestParam(name = "limit", defaultValue = "6") int limit
     ) {
         IdCursorResult<FriendshipResponse> friendships =
-            friendshipService.getFriendshipsByCondition(friendName, cursor, limit);
+            friendshipService.getFriendshipsByName(friendName, cursor, limit);
         return ApiResponse.success(friendships);
     }
 

--- a/src/main/java/com/chaeum/api/domain/friendship/controller/FriendshipController.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/controller/FriendshipController.java
@@ -56,7 +56,7 @@ public class FriendshipController {
     }
 
     @Operation(
-        summary = "조건별 친구 조회",
+        summary = "이름별 친구 조회",
         description = """
             [모든 Role 가능]<br>
             이름을 입력하지 않으면 전체 조회됨<br>

--- a/src/main/java/com/chaeum/api/domain/friendship/controller/FriendshipController.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/controller/FriendshipController.java
@@ -29,7 +29,13 @@ public class FriendshipController {
 
     private final FriendshipService friendshipService;
 
-    @Operation(summary = "친구 등록", description = "[모든 Role 가능]")
+    @Operation(
+        summary = "친구 요청",
+        description = """
+            [모든 Role 가능]<br>
+            친구 요청 시 PENDING으로 친구 관계가 생성됩니다.
+            """
+    )
     @PreAuthorize("hasRole('DONOR')")
     @PostMapping("")
     public ApiResponse<Long> save(
@@ -52,7 +58,7 @@ public class FriendshipController {
     @Operation(
         summary = "조건별 친구 조회",
         description = """
-            [모든 Role 조회 가능]<br>
+            [모든 Role 가능]<br>
             이름을 입력하지 않으면 전체 조회됨<br>
             """
     )
@@ -68,7 +74,7 @@ public class FriendshipController {
         return ApiResponse.success(friendships);
     }
 
-    @Operation(summary = "친구 요청 상태 변경", description = "친구 요청 수락, 거절 등")
+    @Operation(summary = "친구 관계 상태 변경", description = "[모든 Role 가능]")
     @PreAuthorize("hasRole('DONOR')")
     @PatchMapping("")
     public ApiResponse<Long> updateFriendshipStatus(

--- a/src/main/java/com/chaeum/api/domain/friendship/dto/request/FriendshipCreateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/dto/request/FriendshipCreateRequest.java
@@ -1,0 +1,20 @@
+package com.chaeum.api.domain.friendship.dto.request;
+
+import com.chaeum.api.domain.friendship.entity.FriendshipStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FriendshipCreateRequest {
+
+    @NotNull
+    @Schema(description = "대상 친구 관계 ID", example = "2")
+    private Long friendshipId;
+
+    @NotNull
+    @Schema(description = "요청 상태", example = "ACCEPTED")
+    private FriendshipStatus friendshipStatus;
+}

--- a/src/main/java/com/chaeum/api/domain/friendship/dto/request/FriendshipCreateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/dto/request/FriendshipCreateRequest.java
@@ -1,6 +1,5 @@
 package com.chaeum.api.domain.friendship.dto.request;
 
-import com.chaeum.api.domain.friendship.entity.FriendshipStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -11,10 +10,6 @@ import lombok.Setter;
 public class FriendshipCreateRequest {
 
     @NotNull
-    @Schema(description = "대상 친구 관계 ID", example = "2")
-    private Long friendshipId;
-
-    @NotNull
-    @Schema(description = "요청 상태", example = "ACCEPTED")
-    private FriendshipStatus friendshipStatus;
+    @Schema(description = "친구 ID", example = "2")
+    private Long receiverId;
 }

--- a/src/main/java/com/chaeum/api/domain/friendship/dto/request/FriendshipUpdateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/dto/request/FriendshipUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.chaeum.api.domain.friendship.dto.request;
+
+import com.chaeum.api.domain.friendship.entity.FriendshipStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FriendshipUpdateRequest {
+
+    @NotNull
+    @Schema(description = "대상 친구 관계 ID", example = "2")
+    private Long friendshipId;
+
+    @NotNull
+    @Schema(description = "요청 상태", example = "ACCEPTED")
+    private FriendshipStatus friendshipStatus;
+}

--- a/src/main/java/com/chaeum/api/domain/friendship/dto/response/FriendshipResponse.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/dto/response/FriendshipResponse.java
@@ -1,0 +1,39 @@
+package com.chaeum.api.domain.friendship.dto.response;
+
+import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.domain.title.entity.TitleName;
+import com.chaeum.api.global.pagination.provider.IdProvider;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FriendshipResponse implements IdProvider {
+
+    private Long id;
+
+    private Long friendId;
+
+    private String friendName;
+
+    private String friendProfileImage;
+
+    private List<TitleName> friendTitleName;
+
+    private int sharedDonationCount;
+
+    public static FriendshipResponse toDto(
+        Member friend,
+        List<TitleName> activeTitleNames,
+        int sharedDonationCount
+    ) {
+        return FriendshipResponse.builder()
+            .friendId(friend.getId())
+            .friendName(friend.getName())
+            .friendProfileImage(friend.getProfileImage())
+            .friendTitleName(activeTitleNames)
+            .sharedDonationCount(sharedDonationCount)
+            .build();
+    }
+}

--- a/src/main/java/com/chaeum/api/domain/friendship/entity/Friendship.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/entity/Friendship.java
@@ -1,9 +1,17 @@
 package com.chaeum.api.domain.friendship.entity;
 
+import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.global.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,9 +27,42 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "friendship")
-public class Friendship {
+public class Friendship extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "friendship_id")
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "friend_id", nullable = false)
+    private Member friend;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FriendshipStatus status;
+
+    public static Friendship create(Member member, Member friend, FriendshipStatus friendshipStatus) {
+        return Friendship.builder()
+            .member(member)
+            .friend(friend)
+            .status(friendshipStatus)
+            .build();
+    }
+
+    public void accept() {
+        this.status = FriendshipStatus.ACCEPTED;
+    }
+
+    public void reject() {
+        this.status = FriendshipStatus.REJECTED;
+    }
+
+    public void changeStatus(FriendshipStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/friendship/entity/Friendship.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/entity/Friendship.java
@@ -54,6 +54,11 @@ public class Friendship extends BaseEntity {
             .build();
     }
 
+    // 친구 관계에서 현재 로그인한 사용자를 기준으로 상대방을 반환
+    public Member getFriendOf(Member me) {
+        return member.equals(me) ? friend : member;
+    }
+
     public void accept() {
         this.status = FriendshipStatus.ACCEPTED;
     }

--- a/src/main/java/com/chaeum/api/domain/friendship/entity/Friendship.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/entity/Friendship.java
@@ -1,7 +1,13 @@
 package com.chaeum.api.domain.friendship.entity;
 
+import static com.chaeum.api.domain.friendship.entity.FriendshipStatus.ACCEPTED;
+import static com.chaeum.api.domain.friendship.entity.FriendshipStatus.BLOCKED;
+import static com.chaeum.api.domain.friendship.entity.FriendshipStatus.REJECTED;
+
 import com.chaeum.api.domain.member.entity.Member;
 import com.chaeum.api.global.entity.BaseEntity;
+import com.chaeum.api.global.exception.ChaeumException;
+import com.chaeum.api.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,6 +19,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.EnumSet;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,38 +43,59 @@ public class Friendship extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    private Member sender;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "friend_id", nullable = false)
-    private Member friend;
+    private Member receiver;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(name = "status", nullable = false)
     private FriendshipStatus status;
 
-    public static Friendship create(Member member, Member friend, FriendshipStatus friendshipStatus) {
+    public static Friendship create(Member sender, Member receiver) {
         return Friendship.builder()
-            .member(member)
-            .friend(friend)
-            .status(friendshipStatus)
+            .sender(sender)
+            .receiver(receiver)
+            .status(FriendshipStatus.PENDING)
             .build();
     }
 
-    // 친구 관계에서 현재 로그인한 사용자를 기준으로 상대방을 반환
     public Member getFriendOf(Member me) {
-        return member.equals(me) ? friend : member;
+        return sender.equals(me) ? receiver : sender;
     }
 
-    public void accept() {
-        this.status = FriendshipStatus.ACCEPTED;
+    public void updateStatus(Member actor, FriendshipStatus newStatus) {
+        if (isParticipant(actor)) {
+            throw ChaeumException.from(ErrorCode.FORBIDDEN_FRIENDSHIP_ACCESS);
+        }
+
+        if (isSender(actor) && newStatus == FriendshipStatus.CANCELED) {
+            this.status = newStatus;
+            return;
+        }
+
+        if (isReceiver(actor) && EnumSet.of(ACCEPTED, REJECTED, BLOCKED).contains(newStatus)) {
+            this.status = newStatus;
+            return;
+        }
+
+        throw ChaeumException.from(ErrorCode.INVALID_FRIENDSHIP_STATUS_TRANSITION);
     }
 
-    public void reject() {
-        this.status = FriendshipStatus.REJECTED;
+    private boolean isSameMember(Member a, Member b) {
+        return a != null && b != null && a.getId().equals(b.getId());
     }
 
-    public void changeStatus(FriendshipStatus status) {
-        this.status = status;
+    public boolean isParticipant(Member member) {
+        return !isSender(member) && !isReceiver(member);
+    }
+
+    public boolean isSender(Member member) {
+        return isSameMember(sender, member);
+    }
+
+    public boolean isReceiver(Member member) {
+        return isSameMember(receiver, member);
     }
 }

--- a/src/main/java/com/chaeum/api/domain/friendship/entity/FriendshipStatus.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/entity/FriendshipStatus.java
@@ -1,0 +1,45 @@
+package com.chaeum.api.domain.friendship.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FriendshipStatus {
+
+    PENDING("PENDING", "친구 요청 대기") {
+        @Override
+        public void apply(Friendship friendship) {
+            friendship.changeStatus(this);
+        }
+    },
+    ACCEPTED("ACCEPTED", "친구 수락됨") {
+        @Override
+        public void apply(Friendship friendship) {
+            friendship.accept();
+        }
+    },
+    REJECTED("REJECTED", "친구 요청 거절") {
+        @Override
+        public void apply(Friendship friendship) {
+            friendship.reject();
+        }
+    },
+    BLOCKED("BLOCKED", "차단됨") {
+        @Override
+        public void apply(Friendship friendship) {
+            friendship.changeStatus(this);
+        }
+    },
+    CANCELED("CANCELED", "요청 취소됨") {
+        @Override
+        public void apply(Friendship friendship) {
+            friendship.changeStatus(this);
+        }
+    };
+
+    private final String key;
+    private final String description;
+
+    public abstract void apply(Friendship friendship);
+}

--- a/src/main/java/com/chaeum/api/domain/friendship/entity/FriendshipStatus.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/entity/FriendshipStatus.java
@@ -7,39 +7,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum FriendshipStatus {
 
-    PENDING("PENDING", "친구 요청 대기") {
-        @Override
-        public void apply(Friendship friendship) {
-            friendship.changeStatus(this);
-        }
-    },
-    ACCEPTED("ACCEPTED", "친구 수락됨") {
-        @Override
-        public void apply(Friendship friendship) {
-            friendship.accept();
-        }
-    },
-    REJECTED("REJECTED", "친구 요청 거절") {
-        @Override
-        public void apply(Friendship friendship) {
-            friendship.reject();
-        }
-    },
-    BLOCKED("BLOCKED", "차단됨") {
-        @Override
-        public void apply(Friendship friendship) {
-            friendship.changeStatus(this);
-        }
-    },
-    CANCELED("CANCELED", "요청 취소됨") {
-        @Override
-        public void apply(Friendship friendship) {
-            friendship.changeStatus(this);
-        }
-    };
+    PENDING("PENDING", "친구 요청 대기"),
+    ACCEPTED("ACCEPTED", "친구 수락됨"),
+    REJECTED("REJECTED", "친구 요청 거절"),
+    BLOCKED("BLOCKED", "차단됨"),
+    CANCELED("CANCELED", "요청 취소됨");
 
     private final String key;
     private final String description;
-
-    public abstract void apply(Friendship friendship);
 }

--- a/src/main/java/com/chaeum/api/domain/friendship/repository/FriendshipRepository.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/repository/FriendshipRepository.java
@@ -3,13 +3,16 @@ package com.chaeum.api.domain.friendship.repository;
 import com.chaeum.api.domain.friendship.entity.Friendship;
 import com.chaeum.api.domain.friendship.entity.FriendshipStatus;
 import com.chaeum.api.domain.member.entity.Member;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
 
-    boolean existsByMemberAndFriendAndStatus(Member member, Member friend, FriendshipStatus status);
+    boolean existsBySenderAndReceiverAndStatus(Member sender, Member receiver, FriendshipStatus status);
 
-    boolean existsByMemberAndFriend(Member member, Member friend);
+    boolean existsBySenderAndReceiver(Member sender, Member receiver);
+
+    List<Friendship> findBySenderOrReceiverAndStatus(Member sender, Member receiver, FriendshipStatus status);
 }

--- a/src/main/java/com/chaeum/api/domain/friendship/repository/FriendshipRepository.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/repository/FriendshipRepository.java
@@ -1,4 +1,15 @@
 package com.chaeum.api.domain.friendship.repository;
 
-public interface FriendshipRepository {
+import com.chaeum.api.domain.friendship.entity.Friendship;
+import com.chaeum.api.domain.friendship.entity.FriendshipStatus;
+import com.chaeum.api.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
+
+    boolean existsByMemberAndFriendAndStatus(Member member, Member friend, FriendshipStatus status);
+
+    boolean existsByMemberAndFriend(Member member, Member friend);
 }

--- a/src/main/java/com/chaeum/api/domain/friendship/service/FriendshipService.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/service/FriendshipService.java
@@ -63,7 +63,7 @@ public class FriendshipService {
     }
 
     @Transactional(readOnly = true)
-    public IdCursorResult<FriendshipResponse> getFriendshipsByCondition(String friendName, Long cursor, int limit) {
+    public IdCursorResult<FriendshipResponse> getFriendshipsByName(String friendName, Long cursor, int limit) {
         Member current = loginMemberProvider.getCurrentLoginMember();
 
         List<Friendship> friendships = friendshipRepository

--- a/src/main/java/com/chaeum/api/domain/friendship/service/FriendshipService.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/service/FriendshipService.java
@@ -1,4 +1,124 @@
 package com.chaeum.api.domain.friendship.service;
 
+import com.chaeum.api.domain.donation.service.DonationService;
+import com.chaeum.api.domain.friendship.dto.request.FriendshipCreateRequest;
+import com.chaeum.api.domain.friendship.dto.request.FriendshipUpdateRequest;
+import com.chaeum.api.domain.friendship.dto.response.FriendshipResponse;
+import com.chaeum.api.domain.friendship.entity.Friendship;
+import com.chaeum.api.domain.friendship.entity.FriendshipStatus;
+import com.chaeum.api.domain.friendship.repository.FriendshipRepository;
+import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.domain.member.service.MemberService;
+import com.chaeum.api.domain.title.entity.TitleName;
+import com.chaeum.api.domain.title.service.TitleService;
+import com.chaeum.api.global.auth.util.LoginMemberProvider;
+import com.chaeum.api.global.exception.ChaeumException;
+import com.chaeum.api.global.exception.ErrorCode;
+import com.chaeum.api.global.pagination.cursorResult.IdCursorResult;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class FriendshipService {
+
+    private final FriendshipRepository friendshipRepository;
+    private final LoginMemberProvider loginMemberProvider;
+    private final TitleService titleService;
+    private final MemberService memberService;
+    private final DonationService donationService;
+
+    @Transactional
+    public Long save(FriendshipCreateRequest friendshipCreateRequest) {
+        Member sender = loginMemberProvider.getCurrentLoginMember();
+        Member receiver = memberService.findById(friendshipCreateRequest.getFriendshipId());
+        validateNotSelfRequest(sender, receiver);
+        validateDuplicateFriendship(sender, receiver);
+        Friendship friendship = Friendship.create(sender, receiver, friendshipCreateRequest.getFriendshipStatus());
+        friendshipRepository.save(friendship);
+        return friendship.getId();
+    }
+
+    @Transactional
+    public FriendshipResponse getFriend(Long friendshipId) {
+        Friendship friendship = findById(friendshipId);
+        Member me = loginMemberProvider.getCurrentLoginMember();
+        Member friend = friendship.getFriend();
+        validateMyFriendship(me, friend);
+        List<TitleName> activeTitleNames = titleService.getActiveTitleNames(friend);
+        int sharedDonationCount = donationService.getCountSharedDonations(me, friend);
+        return FriendshipResponse.toDto(friend, activeTitleNames, sharedDonationCount);
+    }
+
+    @Transactional(readOnly = true)
+    public IdCursorResult<FriendshipResponse> getFriendshipsByCondition(String friendName, Long cursor, int limit) {
+        Member me = loginMemberProvider.getCurrentLoginMember();
+
+        List<Friendship> friendships = friendshipRepository.findAll().stream()
+            .filter(friendship -> {
+                Member friend = friendship.getFriendOf(me);
+                return (friendName == null || friendName.isBlank()
+                    || friend.getName().toLowerCase().contains(friendName.toLowerCase()))
+                    && (cursor == null || friendship.getId() > cursor);
+            })
+            .sorted(Comparator.comparingLong(Friendship::getId))
+            .collect(Collectors.toList());
+
+        List<FriendshipResponse> responses = friendships.stream()
+            .map(friendship -> {
+                Member friend = friendship.getFriendOf(me);
+                List<TitleName> titleNames = titleService.getActiveTitleNames(friend);
+                int sharedDonationCount = donationService.getCountSharedDonations(me, friend);
+                return FriendshipResponse.toDto(friend, titleNames, sharedDonationCount);
+            })
+            .collect(Collectors.toList());
+
+        return IdCursorResult.of(responses, cursor, limit);
+    }
+
+    @Transactional
+    public Long update(FriendshipUpdateRequest friendshipUpdateRequest) {
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        Friendship friendship = findById(friendshipUpdateRequest.getFriendshipId());
+        validateMyFriendship(member, friendship.getFriend());
+        friendshipUpdateRequest.getFriendshipStatus().apply(friendship);
+        return friendship.getId();
+    }
+
+    @Transactional
+    public Long delete(Long friendshipId) {
+        friendshipRepository.deleteById(friendshipId);
+        return friendshipId;
+    }
+
+    private void validateNotSelfRequest(Member me, Member target) {
+        if (me.getId().equals(target.getId())) {
+            throw ChaeumException.from(ErrorCode.INVALID_SELF_FRIENDSHIP);
+        }
+    }
+
+    private void validateDuplicateFriendship(Member me, Member friend) {
+        boolean exists = friendshipRepository.existsByMemberAndFriend(me, friend)
+            || friendshipRepository.existsByMemberAndFriend(friend, me);
+        if (exists) {
+            throw ChaeumException.from(ErrorCode.ALREADY_FRIENDSHIP_EXISTS);
+        }
+    }
+
+    private void validateMyFriendship(Member me, Member friend) {
+        boolean exists = friendshipRepository.existsByMemberAndFriendAndStatus(me, friend, FriendshipStatus.ACCEPTED)
+            || friendshipRepository.existsByMemberAndFriendAndStatus(friend, me, FriendshipStatus.ACCEPTED);
+        if (!exists) {
+            throw ChaeumException.from(ErrorCode.FRIENDSHIP_NOT_FOUND);
+        }
+    }
+
+    public Friendship findById(Long friendshipId) {
+        return friendshipRepository.findById(friendshipId)
+            .orElseThrow(() -> ChaeumException.from(ErrorCode.FRIENDSHIP_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/friendship/service/FriendshipService.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/service/FriendshipService.java
@@ -35,45 +35,55 @@ public class FriendshipService {
     @Transactional
     public Long save(FriendshipCreateRequest friendshipCreateRequest) {
         Member sender = loginMemberProvider.getCurrentLoginMember();
-        Member receiver = memberService.findById(friendshipCreateRequest.getFriendshipId());
+        Member receiver = memberService.findById(friendshipCreateRequest.getReceiverId());
+
         validateNotSelfRequest(sender, receiver);
         validateDuplicateFriendship(sender, receiver);
-        Friendship friendship = Friendship.create(sender, receiver, friendshipCreateRequest.getFriendshipStatus());
+
+        Friendship friendship = Friendship.create(sender, receiver);
         friendshipRepository.save(friendship);
+
         return friendship.getId();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public FriendshipResponse getFriend(Long friendshipId) {
+        Member current = loginMemberProvider.getCurrentLoginMember();
         Friendship friendship = findById(friendshipId);
-        Member me = loginMemberProvider.getCurrentLoginMember();
-        Member friend = friendship.getFriend();
-        validateMyFriendship(me, friend);
-        List<TitleName> activeTitleNames = titleService.getActiveTitleNames(friend);
-        int sharedDonationCount = donationService.getCountSharedDonations(me, friend);
-        return FriendshipResponse.toDto(friend, activeTitleNames, sharedDonationCount);
+
+        if (friendship.isParticipant(current)) {
+            throw ChaeumException.from(ErrorCode.FORBIDDEN_FRIENDSHIP_ACCESS);
+        }
+
+        Member friend = friendship.getFriendOf(current);
+        List<TitleName> titles = titleService.getActiveTitleNames(friend);
+        int sharedDonationCount = donationService.getCountSharedDonations(current, friend);
+
+        return FriendshipResponse.toDto(friend, titles, sharedDonationCount);
     }
 
     @Transactional(readOnly = true)
     public IdCursorResult<FriendshipResponse> getFriendshipsByCondition(String friendName, Long cursor, int limit) {
-        Member me = loginMemberProvider.getCurrentLoginMember();
+        Member current = loginMemberProvider.getCurrentLoginMember();
 
-        List<Friendship> friendships = friendshipRepository.findAll().stream()
+        List<Friendship> friendships = friendshipRepository
+            .findBySenderOrReceiverAndStatus(current, current, FriendshipStatus.ACCEPTED).stream()
             .filter(friendship -> {
-                Member friend = friendship.getFriendOf(me);
-                return (friendName == null || friendName.isBlank()
-                    || friend.getName().toLowerCase().contains(friendName.toLowerCase()))
-                    && (cursor == null || friendship.getId() > cursor);
+                Member friend = friendship.getFriendOf(current);
+                return !friend.isSame(current) && (
+                    friendName == null || friendName.isBlank()
+                        || friend.getName().toLowerCase().contains(friendName.toLowerCase())
+                ) && (cursor == null || friendship.getId() < cursor);
             })
-            .sorted(Comparator.comparingLong(Friendship::getId))
+            .sorted(Comparator.comparingLong(Friendship::getId).reversed())
             .collect(Collectors.toList());
 
         List<FriendshipResponse> responses = friendships.stream()
             .map(friendship -> {
-                Member friend = friendship.getFriendOf(me);
-                List<TitleName> titleNames = titleService.getActiveTitleNames(friend);
-                int sharedDonationCount = donationService.getCountSharedDonations(me, friend);
-                return FriendshipResponse.toDto(friend, titleNames, sharedDonationCount);
+                Member friend = friendship.getFriendOf(current);
+                List<TitleName> titles = titleService.getActiveTitleNames(friend);
+                int sharedDonationCount = donationService.getCountSharedDonations(current, friend);
+                return FriendshipResponse.toDto(friend, titles, sharedDonationCount);
             })
             .collect(Collectors.toList());
 
@@ -82,10 +92,11 @@ public class FriendshipService {
 
     @Transactional
     public Long update(FriendshipUpdateRequest friendshipUpdateRequest) {
-        Member member = loginMemberProvider.getCurrentLoginMember();
+        Member current = loginMemberProvider.getCurrentLoginMember();
         Friendship friendship = findById(friendshipUpdateRequest.getFriendshipId());
-        validateMyFriendship(member, friendship.getFriend());
-        friendshipUpdateRequest.getFriendshipStatus().apply(friendship);
+
+        friendship.updateStatus(current, friendshipUpdateRequest.getFriendshipStatus());
+
         return friendship.getId();
     }
 
@@ -102,18 +113,10 @@ public class FriendshipService {
     }
 
     private void validateDuplicateFriendship(Member me, Member friend) {
-        boolean exists = friendshipRepository.existsByMemberAndFriend(me, friend)
-            || friendshipRepository.existsByMemberAndFriend(friend, me);
+        boolean exists = friendshipRepository.existsBySenderAndReceiver(me, friend)
+            || friendshipRepository.existsBySenderAndReceiver(friend, me);
         if (exists) {
             throw ChaeumException.from(ErrorCode.ALREADY_FRIENDSHIP_EXISTS);
-        }
-    }
-
-    private void validateMyFriendship(Member me, Member friend) {
-        boolean exists = friendshipRepository.existsByMemberAndFriendAndStatus(me, friend, FriendshipStatus.ACCEPTED)
-            || friendshipRepository.existsByMemberAndFriendAndStatus(friend, me, FriendshipStatus.ACCEPTED);
-        if (!exists) {
-            throw ChaeumException.from(ErrorCode.FRIENDSHIP_NOT_FOUND);
         }
     }
 

--- a/src/main/java/com/chaeum/api/domain/friendship/service/FriendshipService.java
+++ b/src/main/java/com/chaeum/api/domain/friendship/service/FriendshipService.java
@@ -107,7 +107,7 @@ public class FriendshipService {
     }
 
     private void validateNotSelfRequest(Member me, Member target) {
-        if (me.getId().equals(target.getId())) {
+        if (me.isSame(target)) {
             throw ChaeumException.from(ErrorCode.INVALID_SELF_FRIENDSHIP);
         }
     }

--- a/src/main/java/com/chaeum/api/domain/member/entity/Member.java
+++ b/src/main/java/com/chaeum/api/domain/member/entity/Member.java
@@ -76,6 +76,12 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Donation> donations;
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Friendship> friendships;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Title> titles;
+
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 //    private List<MissionProgress> missionProgresses;
 //

--- a/src/main/java/com/chaeum/api/domain/member/entity/Member.java
+++ b/src/main/java/com/chaeum/api/domain/member/entity/Member.java
@@ -2,9 +2,11 @@ package com.chaeum.api.domain.member.entity;
 
 import com.chaeum.api.domain.cat.entity.Cat;
 import com.chaeum.api.domain.donation.entity.Donation;
+import com.chaeum.api.domain.friendship.entity.Friendship;
 import com.chaeum.api.domain.inventory.entity.Inventory;
 import com.chaeum.api.domain.member.dto.request.MemberUpdateRequest;
 import com.chaeum.api.domain.paymentRecord.entity.PaymentRecord;
+import com.chaeum.api.domain.title.entity.Title;
 import com.chaeum.api.global.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -84,19 +86,13 @@ public class Member extends BaseEntity {
 
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 //    private List<MissionProgress> missionProgresses;
-//
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Friendship> friendships;
 
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 //    private List<Attendance> attendances;
-//
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Title> titles;
-//
+
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 //    private List<Notification> notifications;
-//
+
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 //    private List<Review> reviews;
 

--- a/src/main/java/com/chaeum/api/domain/member/entity/Member.java
+++ b/src/main/java/com/chaeum/api/domain/member/entity/Member.java
@@ -69,20 +69,29 @@ public class Member extends BaseEntity {
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private Cat cat;
 
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Inventory> inventoryItems;
+    private List<Inventory> inventoryItems = List.of();
 
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PaymentRecord> payments;
+    private List<PaymentRecord> payments = List.of();
 
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Donation> donations;
+    private List<Donation> donations = List.of();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Friendship> friendships;
+    @Builder.Default
+    @OneToMany(mappedBy = "sender", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Friendship> sentFriendships = List.of();
 
+    @Builder.Default
+    @OneToMany(mappedBy = "receiver", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Friendship> receivedFriendships = List.of();
+
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Title> titles;
+    private List<Title> titles = List.of();
 
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 //    private List<MissionProgress> missionProgresses;
@@ -99,5 +108,9 @@ public class Member extends BaseEntity {
     public void update(MemberUpdateRequest memberUpdateRequest) {
         Optional.ofNullable(memberUpdateRequest.getName()).ifPresent(this::setName);
         Optional.ofNullable(memberUpdateRequest.getProfileImage()).ifPresent(this::setProfileImage);
+    }
+
+    public boolean isSame(Member other) {
+        return other != null && this.id != null && this.id.equals(other.getId());
     }
 }

--- a/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/chaeum/api/domain/member/service/MemberService.java
@@ -61,8 +61,8 @@ public class MemberService {
         return DonorMyPageResponse.toDto(member, monthlyAmount, yearlyAmount, donations);
     }
 
-    private Member findById(Long memberId) {
+    public Member findById(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> ChaeumException.from(ErrorCode.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> ChaeumException.from(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/chaeum/api/domain/title/controller/TitleController.java
+++ b/src/main/java/com/chaeum/api/domain/title/controller/TitleController.java
@@ -1,4 +1,16 @@
 package com.chaeum.api.domain.title.controller;
 
+import com.chaeum.api.domain.title.service.TitleService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/title")
+@RequiredArgsConstructor
+@Tag(name = "Title", description = "칭호 관리")
 public class TitleController {
+
+    private final TitleService titleService;
 }

--- a/src/main/java/com/chaeum/api/domain/title/entity/Title.java
+++ b/src/main/java/com/chaeum/api/domain/title/entity/Title.java
@@ -1,9 +1,17 @@
 package com.chaeum.api.domain.title.entity;
 
+import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.global.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,9 +27,21 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "title")
-public class Title {
+public class Title extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "title_id")
     private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "title_name", nullable = false)
+    private TitleName name;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = Boolean.FALSE;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 }

--- a/src/main/java/com/chaeum/api/domain/title/entity/TitleName.java
+++ b/src/main/java/com/chaeum/api/domain/title/entity/TitleName.java
@@ -1,0 +1,19 @@
+package com.chaeum.api.domain.title.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TitleName {
+
+    DONATION_ANGEL("DONATION_ANGEL", "기부 천사"),
+    EARLY_BIRD("EARLY_BIRD", "얼리버드"),
+    CHALLENGER("CHALLENGER", "도전가"),
+    FRIENDSHIP_MASTER("FRIENDSHIP_MASTER", "친구왕"),
+    SUPER_SUPPORTER("SUPER_SUPPORTER", "슈퍼 서포터"),
+    MONTHLY_TOP_DONOR("MONTHLY_TOP_DONOR", "이달의 기부왕");
+
+    private final String key;
+    private final String description;
+}

--- a/src/main/java/com/chaeum/api/domain/title/repository/TitleRepository.java
+++ b/src/main/java/com/chaeum/api/domain/title/repository/TitleRepository.java
@@ -1,4 +1,16 @@
 package com.chaeum.api.domain.title.repository;
 
-public interface TitleRepository {
+import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.domain.title.entity.Title;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TitleRepository extends JpaRepository<Title, Long> {
+
+    List<Title> findByIsActiveTrue();
+
+    Optional<Title> findByMemberAndIsActiveTrue(Member member);
 }

--- a/src/main/java/com/chaeum/api/domain/title/service/TitleService.java
+++ b/src/main/java/com/chaeum/api/domain/title/service/TitleService.java
@@ -1,4 +1,24 @@
 package com.chaeum.api.domain.title.service;
 
+import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.domain.title.entity.Title;
+import com.chaeum.api.domain.title.entity.TitleName;
+import com.chaeum.api.domain.title.repository.TitleRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class TitleService {
+
+    private final TitleRepository titleRepository;
+
+    @Transactional(readOnly = true)
+    public List<TitleName> getActiveTitleNames(Member member) {
+        return titleRepository.findByIsActiveTrue().stream()
+            .map(Title::getName)
+            .toList();
+    }
 }

--- a/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     NOT_FOUND_ACCESS_TOKEN(HttpStatus.NOT_FOUND, "엑세스 토큰을 찾을 수 없습니다."),
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "리프레시 토큰을 찾을 수 없습니다."),
     CAT_NOT_FOUND(HttpStatus.NOT_FOUND, "고양이를 찾을 수 없습니다."),
+    FRIENDSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "친구 관계를 찾을 수 없습니다."),
 
     // 409: CONFLICT (중복된 요청)
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),

--- a/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode {
     PAYMENT_VERIFY_FAILED(HttpStatus.BAD_REQUEST, "결제 검증에 실패했습니다."),
     INVALID_FRIENDSHIP_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 친구 상태입니다."),
     INVALID_SELF_FRIENDSHIP(HttpStatus.BAD_REQUEST, "자기 자신과 친구할 수 없습니다."),
+    INVALID_FRIENDSHIP_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "잘못된 친구 상태 전이입니다."),
+    INVALID_FRIENDSHIP_ACTION(HttpStatus.BAD_REQUEST, "현재 상태에서 허용되지 않는 친구 요청 처리입니다."),
 
     // 401: UNAUTHORIZED (인증 실패)
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
@@ -37,6 +39,7 @@ public enum ErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
     MEMBER_NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
     NOT_ENOUGH_PERMISSION(HttpStatus.FORBIDDEN, "권한이 부족합니다."),
+    FORBIDDEN_FRIENDSHIP_ACCESS(HttpStatus.FORBIDDEN, "해당 친구 요청에 접근할 수 있는 권한이 없습니다."),
 
     // 404: NOT FOUND (리소스를 찾을 수 없음)
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),

--- a/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
     INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 상태입니다."),
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
     PAYMENT_VERIFY_FAILED(HttpStatus.BAD_REQUEST, "결제 검증에 실패했습니다."),
+    INVALID_FRIENDSHIP_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 친구 상태입니다."),
+    INVALID_SELF_FRIENDSHIP(HttpStatus.BAD_REQUEST, "자기 자신과 친구할 수 없습니다."),
 
     // 401: UNAUTHORIZED (인증 실패)
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
@@ -53,6 +55,7 @@ public enum ErrorCode {
     // 409: CONFLICT (중복된 요청)
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
     DUPLICATE_MEMBER_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    ALREADY_FRIENDSHIP_EXISTS(HttpStatus.CONFLICT, "이미 친구 관계가 존재합니다."),
 
     // 500: INTERNAL SERVER ERROR (서버 내부 오류)
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),

--- a/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
@@ -20,10 +20,10 @@ public enum ErrorCode {
     INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 상태입니다."),
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
     PAYMENT_VERIFY_FAILED(HttpStatus.BAD_REQUEST, "결제 검증에 실패했습니다."),
-    INVALID_FRIENDSHIP_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 친구 상태입니다."),
-    INVALID_SELF_FRIENDSHIP(HttpStatus.BAD_REQUEST, "자기 자신과 친구할 수 없습니다."),
-    INVALID_FRIENDSHIP_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "잘못된 친구 상태 전이입니다."),
-    INVALID_FRIENDSHIP_ACTION(HttpStatus.BAD_REQUEST, "현재 상태에서 허용되지 않는 친구 요청 처리입니다."),
+    INVALID_FRIENDSHIP_STATUS(HttpStatus.BAD_REQUEST, "존재하지 않거나 잘못된 친구 상태입니다."),
+    INVALID_SELF_FRIENDSHIP(HttpStatus.BAD_REQUEST, "자기 자신에게 친구 요청을 보낼 수 없습니다."),
+    INVALID_FRIENDSHIP_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "현재 친구 상태에서는 해당 변경이 불가능합니다."),
+    INVALID_FRIENDSHIP_ACTION(HttpStatus.BAD_REQUEST, "현재 친구 상태에서는 이 요청을 처리할 수 없습니다."),
 
     // 401: UNAUTHORIZED (인증 실패)
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),


### PR DESCRIPTION
## ⭐️ Overview

> #78

친구 기능 API를 구현했습니다.

## 🔧 Tasks

- 친구 생성
- 친구 단건 조회
- 친구 조건별 조회
- 친구 전체 조회
- 친구관계 상태 변화(수락, 요청)
- 친구 삭제
- 회원 칭호 정보 조회
- 두 회원의 공동 기부 횟수 조회

## 📝 Additional Notes

- 처음에 친구 생성은 `PENDING` 상태로 저장됩니다.
친구 관계는 Friendship이라는 중간 테이블 하나로 관리되므로, 두 회원의 외래키와 함께 DB에 하나만 저장됩니다.
- 상대방이 친구 요청을 수락하면 상태가 `ACCEPTED`로 변경되며, 이때부터 친구로 간주됩니다.
- 친구 목록 조회는 `ACCEPTED` 상태만 조회되며, 내림차순으로 정렬하여 최근에 친구가 된 회원부터 보이도록 설정했습니다.
- ERD 설계에는 `Member`쪽에 단방향으로만 `Friendship` 매핑으로 설정되어있었으나, 
친구 요청과 수락자 구분이 더 좋은 설계라 생각하여 분리하였습니다.
- 작업하면서 NPE 방지를 위해 `Member` 필드 일부를 @Builder.Default와 List.of()로 초기화 해주었습니다.
- 두 회원의 공동 기부 횟수 조회 구현 과정에서 `Donation`엔티티를 건드렸는데 풀 받으실 때 참고해주시면 감사하겠습니다~!

## 📸 Screenshot

### 친구 생성

회원1이 회원4에게 친구 요청을 한 상황
`PENDING`으로 두 회원의 친구 관계 생성됨

<img width="300" alt="친구 요청 생성 화면" src="https://github.com/user-attachments/assets/49c2a407-2217-4fed-ba3b-f7bb8734ecf2" /><br>

### 친구 상태 변경

회원2가 회원1에게 친구를 보낸 상황
친구1은 친구관계 상태를 `PENDING` -> `ACCEPTED`로 변경

<img width="300" alt="친구 수락 후 상태 변경 화면" src="https://github.com/user-attachments/assets/bfce8838-3743-49de-9454-0e17b195688b" /><br>

### 친구 삭제

<img width="300" alt="친구 삭제 화면" src="https://github.com/user-attachments/assets/be2d3402-739f-4f72-8174-315457271558" /><br>

### 친구 전체 조회

회원4: `PENDING` 상태 → 목록에서 제외
민상친구1: 같은 펀딩에 참여한 이력이 있어 함께 표시됨

<img width="400" alt="전체 친구 목록 조회 화면" src="https://github.com/user-attachments/assets/70c7407c-f979-431c-98f8-2e9a01692474" /><br>

### 이름으로 친구 조회

친구 이름에 "민상"이라는 이름이 들어가는 조회 결과입니다.

<img width="500" alt="친구 이름 검색 화면" src="https://github.com/user-attachments/assets/95988053-e400-40d6-9393-a3c1f5d7aa7d" /><br>