### PR TITLE
feat: 펀딩 후기 기능 구현 완료

### DIFF
--- a/src/main/java/com/chaeum/api/domain/donation/entity/Donation.java
+++ b/src/main/java/com/chaeum/api/domain/donation/entity/Donation.java
@@ -4,6 +4,7 @@ import com.chaeum.api.domain.donation.dto.request.DonationCreateRequest;
 import com.chaeum.api.domain.funding.entity.Funding;
 import com.chaeum.api.domain.member.entity.Member;
 import com.chaeum.api.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -42,7 +43,7 @@ public class Donation extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "funding_id", nullable = false)
     private Funding funding;
 

--- a/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingResponse.java
+++ b/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingResponse.java
@@ -33,6 +33,8 @@ public class FundingResponse implements IdProvider {
 
     private LocalDateTime endDate;
 
+    private Boolean isReviewed;
+
     private LocalDateTime createdAt;
 
     public static FundingResponse toDto(Funding funding) {
@@ -47,6 +49,7 @@ public class FundingResponse implements IdProvider {
                 .currentAmount(funding.getCurrentAmount())
                 .status(funding.getStatus())
                 .endDate(funding.getEndDate())
+                .isReviewed(funding.getIsReviewed())
                 .createdAt(funding.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingSummaryResponse.java
+++ b/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingSummaryResponse.java
@@ -19,6 +19,8 @@ public class FundingSummaryResponse {
 
     private BigDecimal amount;
 
+    private Boolean isReviewed;
+
     private LocalDateTime createdAt;
 
     public static FundingSummaryResponse toDto(Funding funding) {
@@ -27,6 +29,8 @@ public class FundingSummaryResponse {
                 .title(funding.getTitle())
                 .fundingImage(funding.getFundingImage())
                 .amount(funding.getCurrentAmount())
+                .isReviewed(funding.getIsReviewed())
+                .createdAt(funding.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/chaeum/api/domain/funding/entity/Funding.java
+++ b/src/main/java/com/chaeum/api/domain/funding/entity/Funding.java
@@ -17,16 +17,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.Optional;
 
 @Entity
 @Getter
@@ -74,6 +73,9 @@ public class Funding extends BaseEntity {
     @Column(name = "end_date")
     private LocalDateTime endDate;
 
+    @Column(name = "is_reviewed")
+    private Boolean isReviewed;
+
     public static Funding toEntity(FundingCreateRequest fundingCreateRequest, Member member) {
         return Funding.builder()
                 .member(member)
@@ -82,9 +84,11 @@ public class Funding extends BaseEntity {
                 .fundingImage(fundingCreateRequest.getFundingImage())
                 .itemLink(fundingCreateRequest.getItemLink())
                 .address(fundingCreateRequest.getAddress())
+                .goalAmount(fundingCreateRequest.getGoalAmount())
                 .currentAmount(BigDecimal.ZERO)
                 .status(FundingStatus.ONGOING)
                 .endDate(fundingCreateRequest.getEndDate())
+                .isReviewed(Boolean.FALSE)
                 .build();
     }
 
@@ -108,6 +112,24 @@ public class Funding extends BaseEntity {
     public void addCurrentAmount(BigDecimal amount) {
         validateAmount(amount);
         this.currentAmount = this.currentAmount.add(amount);
+    }
+
+    public void markReviewed() {
+        if (this.isReviewed == Boolean.FALSE) {
+            this.isReviewed = Boolean.TRUE;
+        }
+    }
+
+    public void validateGoalReached() {
+        if (this.currentAmount.compareTo(this.goalAmount) < 0) {
+            throw ChaeumException.from(ErrorCode.GOAL_AMOUNT_NOT_REACHED);
+        }
+    }
+
+    public void validateStatusCompleted() {
+        if (this.status != FundingStatus.COMPLETED) {
+            throw ChaeumException.from(ErrorCode.FUNDING_IS_NOT_COMPLETED);
+        }
     }
 
     private void validateAmount(BigDecimal amount) {

--- a/src/main/java/com/chaeum/api/domain/member/entity/Member.java
+++ b/src/main/java/com/chaeum/api/domain/member/entity/Member.java
@@ -62,6 +62,7 @@ public class Member extends BaseEntity {
     @Column(name = "profile_image")
     private String profileImage;
 
+    @Builder.Default
     @Column(name = "points", nullable = false, precision = 10, scale = 2)
     private BigDecimal points = BigDecimal.ZERO;
 

--- a/src/main/java/com/chaeum/api/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/chaeum/api/domain/review/controller/ReviewController.java
@@ -67,7 +67,7 @@ public class ReviewController {
     @PreAuthorize("hasRole('RECIPIENT')")
     @PatchMapping("")
     public ApiResponse<Long> update(
-        @RequestParam(name = "reviewId") Long fundingId,
+        @RequestParam(name = "fundingId") Long fundingId,
         @Valid @RequestBody ReviewUpdateRequest reviewUpdateRequest
     ) {
         Long id = reviewService.update(fundingId, reviewUpdateRequest);

--- a/src/main/java/com/chaeum/api/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/chaeum/api/domain/review/controller/ReviewController.java
@@ -1,8 +1,26 @@
 package com.chaeum.api.domain.review.controller;
 
+import com.chaeum.api.domain.review.dto.request.ReviewCreateRequest;
+import com.chaeum.api.domain.review.dto.request.ReviewUpdateRequest;
+import com.chaeum.api.domain.review.dto.response.ReviewResponse;
+import com.chaeum.api.domain.review.dto.response.ReviewSummaryResponse;
+import com.chaeum.api.domain.review.service.ReviewService;
+import com.chaeum.api.global.pagination.cursorResult.CreatedAtCursorResult;
+import com.chaeum.api.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -10,4 +28,59 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Tag(name = "Review", description = "펀딩 후기 관리")
 public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @Operation(summary = "펀딩 후기 등록", description = "[RECIPIENT 이상 가능]")
+    @PreAuthorize("hasRole('RECIPIENT')")
+    @PostMapping("")
+    public ApiResponse<Long> save(
+        @RequestParam(name = "fundingId") Long fundingId,
+        @Valid @RequestBody ReviewCreateRequest reviewCreateRequest
+    ) {
+        Long id = reviewService.save(fundingId, reviewCreateRequest);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(summary = "펀딩 후기 상세 조회", description = "[모든 Role 가능] 펀딩 ID로 후기 상세 정보를 조회합니다.")
+    @PreAuthorize("hasRole('DONOR')")
+    @GetMapping("/details")
+    public ApiResponse<ReviewResponse> getReviewDetails(
+        @RequestParam(name = "fundingId") Long fundingId
+    ) {
+        ReviewResponse reviewResponse = reviewService.getReviewDetails(fundingId);
+        return ApiResponse.success(reviewResponse);
+    }
+
+    @Operation(summary = "펀딩 후기 목록 조회", description = "[모든 Role 가능] 후기 최신순으로 조회합니다.")
+    @PreAuthorize("hasRole('DONOR')")
+    @GetMapping("/list")
+    public ApiResponse<CreatedAtCursorResult<ReviewSummaryResponse>> getReviews(
+        @RequestParam(name = "cursor", required = false) LocalDateTime cursor,
+        @RequestParam(name = "limit", defaultValue = "8") int limit
+    ) {
+        CreatedAtCursorResult<ReviewSummaryResponse> reviews = reviewService.getReviews(cursor, limit);
+        return ApiResponse.success(reviews);
+    }
+
+    @Operation(summary = "펀딩 후기 변경", description = "[RECIPIENT 이상 가능]")
+    @PreAuthorize("hasRole('RECIPIENT')")
+    @PatchMapping("")
+    public ApiResponse<Long> update(
+        @RequestParam(name = "reviewId") Long fundingId,
+        @Valid @RequestBody ReviewUpdateRequest reviewUpdateRequest
+    ) {
+        Long id = reviewService.update(fundingId, reviewUpdateRequest);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(summary = "펀딩 후기 삭제", description = "[ADMIN 이상 가능]")
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{reviewId}")
+    public ApiResponse<Long> delete(
+        @PathVariable(name = "reviewId") Long reviewId
+    ) {
+        Long id = reviewService.delete(reviewId);
+        return ApiResponse.success(id);
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/review/dto/request/ReviewCreateRequest.java
@@ -1,0 +1,30 @@
+package com.chaeum.api.domain.review.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReviewCreateRequest {
+
+    @NotNull
+    @Size(max = 100, message = "펀딩 후기 제목은 최대 100자까지 입력할 수 있습니다.")
+    @Schema(description = "펀딩 후기 제목", example = "후원해주셔서 정말 감사합니다.")
+    private String title;
+
+    @NotNull
+    @Size(max = 1000, message = "펀딩 후기 내용은 최대 1000자까지 입력할 수 있습니다.")
+    @Schema(description = "펀딩 내용", example = "덕분에 사정이 나아졌습니다.")
+    private String content;
+
+    @NotNull
+    @Schema(
+        description = "리뷰 사진 URL",
+        example = "[\"https://s3.ap-northeast-2.amazonaws.com/item/764q13ef-7301-22D2-a1d4-e7c8cw4.png\"]"
+    )
+    private List<String> imageUrls;
+}

--- a/src/main/java/com/chaeum/api/domain/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/review/dto/request/ReviewUpdateRequest.java
@@ -1,0 +1,30 @@
+package com.chaeum.api.domain.review.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReviewUpdateRequest {
+
+    @NotNull
+    @Size(max = 100, message = "펀딩 후기 제목은 최대 100자까지 입력할 수 있습니다.")
+    @Schema(description = "펀딩 후기 제목", example = "도와주셔서 감사합니다.")
+    private String title;
+
+    @NotNull
+    @Size(max = 1000, message = "펀딩 후기 내용은 최대 1000자까지 입력할 수 있습니다.")
+    @Schema(description = "펀딩 후기 내용", example = "덕분에 도움이 많이 되었습니다.")
+    private String content;
+
+    @NotNull
+    @Schema(
+        description = "리뷰 사진 URL",
+        example = "[\"https://bucket.s3.ap-northeast-2.amazonaws.com/item/764c13ef-7301-22D2-a1d4-e7c8cw4.png\"]"
+    )
+    private List<String> imageUrls;
+}

--- a/src/main/java/com/chaeum/api/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/chaeum/api/domain/review/dto/response/ReviewResponse.java
@@ -1,0 +1,35 @@
+package com.chaeum.api.domain.review.dto.response;
+
+import com.chaeum.api.domain.review.entity.Review;
+import com.chaeum.api.global.file.dto.ExternalFileResponse;
+import com.chaeum.api.global.file.entity.UploadedFile;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewResponse {
+
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private List<ExternalFileResponse> reviewImages;
+
+    private LocalDateTime createdAt;
+
+    public static ReviewResponse toDto(Review review) {
+        List<UploadedFile> files = review.getReviewImages();
+        return ReviewResponse.builder()
+            .id(review.getId())
+            .title(review.getTitle())
+            .content(review.getContent())
+            .reviewImages(ExternalFileResponse.toListDto(files))
+            .createdAt(review.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/chaeum/api/domain/review/dto/response/ReviewSummaryResponse.java
+++ b/src/main/java/com/chaeum/api/domain/review/dto/response/ReviewSummaryResponse.java
@@ -5,6 +5,7 @@ import com.chaeum.api.global.file.dto.ExternalFileResponse;
 import com.chaeum.api.global.file.entity.UploadedFile;
 import com.chaeum.api.global.pagination.provider.CreatedAtProvider;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -21,11 +22,15 @@ public class ReviewSummaryResponse implements CreatedAtProvider {
     private LocalDateTime createdAt;
 
     public static ReviewSummaryResponse toDto(Review review) {
-        UploadedFile file = review.getReviewImages().getFirst();
+        Optional<UploadedFile> firstFile = review.getReviewImages().stream().findFirst();
+        ExternalFileResponse imageDto = firstFile
+            .map(ExternalFileResponse::toDto)
+            .orElse(null);
+
         return ReviewSummaryResponse.builder()
             .id(review.getId())
             .title(review.getTitle())
-            .reviewImage(ExternalFileResponse.toDto(file))
+            .reviewImage(imageDto)
             .createdAt(review.getCreatedAt())
             .build();
     }

--- a/src/main/java/com/chaeum/api/domain/review/dto/response/ReviewSummaryResponse.java
+++ b/src/main/java/com/chaeum/api/domain/review/dto/response/ReviewSummaryResponse.java
@@ -1,0 +1,32 @@
+package com.chaeum.api.domain.review.dto.response;
+
+import com.chaeum.api.domain.review.entity.Review;
+import com.chaeum.api.global.file.dto.ExternalFileResponse;
+import com.chaeum.api.global.file.entity.UploadedFile;
+import com.chaeum.api.global.pagination.provider.CreatedAtProvider;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewSummaryResponse implements CreatedAtProvider {
+
+    private Long id;
+
+    private String title;
+
+    private ExternalFileResponse reviewImage;
+
+    private LocalDateTime createdAt;
+
+    public static ReviewSummaryResponse toDto(Review review) {
+        UploadedFile file = review.getReviewImages().getFirst();
+        return ReviewSummaryResponse.builder()
+            .id(review.getId())
+            .title(review.getTitle())
+            .reviewImage(ExternalFileResponse.toDto(file))
+            .createdAt(review.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/chaeum/api/domain/review/entity/Review.java
+++ b/src/main/java/com/chaeum/api/domain/review/entity/Review.java
@@ -1,10 +1,23 @@
 package com.chaeum.api.domain.review.entity;
 
+import com.chaeum.api.domain.funding.entity.Funding;
+import com.chaeum.api.domain.review.dto.request.ReviewCreateRequest;
+import com.chaeum.api.domain.review.dto.request.ReviewUpdateRequest;
+import com.chaeum.api.global.entity.BaseEntity;
+import com.chaeum.api.global.file.entity.UploadedFile;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,9 +32,41 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "review")
-public class Review {
+public class Review extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
     private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "funding_id", nullable = false)
+    private Funding funding;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "review_images")
+    private List<UploadedFile> reviewImages;
+
+    public static Review toEntity(
+        Funding funding, List<UploadedFile> files, ReviewCreateRequest reviewCreateRequest
+    ) {
+        return Review.builder()
+            .funding(funding)
+            .title(reviewCreateRequest.getTitle())
+            .content(reviewCreateRequest.getContent())
+            .reviewImages(files)
+            .build();
+    }
+
+    public void update(List<UploadedFile> files, ReviewUpdateRequest reviewUpdateRequest) {
+        Optional.ofNullable(reviewUpdateRequest.getTitle()).ifPresent(this::setTitle);
+        Optional.ofNullable(reviewUpdateRequest.getContent()).ifPresent(this::setContent);
+        Optional.ofNullable(files).ifPresent(this::setReviewImages);
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/review/entity/Review.java
+++ b/src/main/java/com/chaeum/api/domain/review/entity/Review.java
@@ -50,7 +50,7 @@ public class Review extends BaseEntity {
     private String content;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "review_images")
+    @JoinColumn(name = "review_id")
     private List<UploadedFile> reviewImages;
 
     public static Review toEntity(

--- a/src/main/java/com/chaeum/api/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/chaeum/api/domain/review/repository/ReviewRepository.java
@@ -1,9 +1,12 @@
 package com.chaeum.api.domain.review.repository;
 
 import com.chaeum.api.domain.review.entity.Review;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    Optional<Review> findByFundingId(Long fundingId);
 }

--- a/src/main/java/com/chaeum/api/domain/review/service/ReviewService.java
+++ b/src/main/java/com/chaeum/api/domain/review/service/ReviewService.java
@@ -59,11 +59,11 @@ public class ReviewService {
     }
 
     @Transactional
-    public Long update(Long reviewId, ReviewUpdateRequest reviewUpdateRequest) {
-        Review review = getReview(reviewId);
+    public Long update(Long fundingId, ReviewUpdateRequest reviewUpdateRequest) {
+        Review review = getReview(fundingId);
         List<UploadedFile> files = fileService.getUploadedFilesByUrls(reviewUpdateRequest.getImageUrls());
         review.update(files, reviewUpdateRequest);
-        return reviewId;
+        return review.getId();
     }
 
     @Transactional

--- a/src/main/java/com/chaeum/api/domain/review/service/ReviewService.java
+++ b/src/main/java/com/chaeum/api/domain/review/service/ReviewService.java
@@ -51,7 +51,7 @@ public class ReviewService {
         List<Review> reviews = reviewRepository.findAll();
         List<ReviewSummaryResponse> filteredReviews = reviews.stream()
             .filter(review -> cursor == null || review.getCreatedAt().isAfter(cursor))
-            .sorted(Comparator.comparing(Review::getCreatedAt))
+            .sorted(Comparator.comparing(Review::getCreatedAt).reversed())
             .map(ReviewSummaryResponse::toDto)
             .collect(Collectors.toList());
 

--- a/src/main/java/com/chaeum/api/domain/review/service/ReviewService.java
+++ b/src/main/java/com/chaeum/api/domain/review/service/ReviewService.java
@@ -1,9 +1,79 @@
 package com.chaeum.api.domain.review.service;
 
+import com.chaeum.api.domain.funding.entity.Funding;
+import com.chaeum.api.domain.funding.service.FundingService;
+import com.chaeum.api.domain.review.dto.request.ReviewCreateRequest;
+import com.chaeum.api.domain.review.dto.request.ReviewUpdateRequest;
+import com.chaeum.api.domain.review.dto.response.ReviewResponse;
+import com.chaeum.api.domain.review.dto.response.ReviewSummaryResponse;
+import com.chaeum.api.domain.review.entity.Review;
+import com.chaeum.api.domain.review.repository.ReviewRepository;
+import com.chaeum.api.global.exception.ChaeumException;
+import com.chaeum.api.global.exception.ErrorCode;
+import com.chaeum.api.global.file.entity.UploadedFile;
+import com.chaeum.api.global.file.service.FileService;
+import com.chaeum.api.global.pagination.cursorResult.CreatedAtCursorResult;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final FundingService fundingService;
+    private final FileService fileService;
+
+    @Transactional
+    public Long save(Long fundingId, ReviewCreateRequest reviewCreateRequest) {
+        Funding funding = fundingService.findById(fundingId);
+        funding.validateStatusCompleted();
+        funding.validateGoalReached();
+        List<UploadedFile> files = fileService.getUploadedFilesByUrls(reviewCreateRequest.getImageUrls());
+        Review review = Review.toEntity(funding, files, reviewCreateRequest);
+        funding.markReviewed();
+        return reviewRepository.save(review).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public ReviewResponse getReviewDetails(Long fundingId) {
+        Review review = getReview(fundingId);
+        return ReviewResponse.toDto(review);
+    }
+
+    @Transactional(readOnly = true)
+    public CreatedAtCursorResult<ReviewSummaryResponse> getReviews(LocalDateTime cursor, int limit) {
+        List<Review> reviews = reviewRepository.findAll();
+        List<ReviewSummaryResponse> filteredReviews = reviews.stream()
+            .filter(review -> cursor == null || review.getCreatedAt().isAfter(cursor))
+            .sorted(Comparator.comparing(Review::getCreatedAt))
+            .map(ReviewSummaryResponse::toDto)
+            .collect(Collectors.toList());
+
+        return CreatedAtCursorResult.of(filteredReviews, cursor, limit);
+    }
+
+    @Transactional
+    public Long update(Long reviewId, ReviewUpdateRequest reviewUpdateRequest) {
+        Review review = getReview(reviewId);
+        List<UploadedFile> files = fileService.getUploadedFilesByUrls(reviewUpdateRequest.getImageUrls());
+        review.update(files, reviewUpdateRequest);
+        return reviewId;
+    }
+
+    @Transactional
+    public Long delete(Long reviewId) {
+        reviewRepository.deleteById(reviewId);
+        return reviewId;
+    }
+
+    private Review getReview(Long fundingId) {
+        return reviewRepository.findByFundingId(fundingId)
+            .orElseThrow(() -> ChaeumException.from(ErrorCode.REVIEW_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
     INVALID_SELF_FRIENDSHIP(HttpStatus.BAD_REQUEST, "자기 자신에게 친구 요청을 보낼 수 없습니다."),
     INVALID_FRIENDSHIP_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "현재 친구 상태에서는 해당 변경이 불가능합니다."),
     INVALID_FRIENDSHIP_ACTION(HttpStatus.BAD_REQUEST, "현재 친구 상태에서는 이 요청을 처리할 수 없습니다."),
+    GOAL_AMOUNT_NOT_REACHED(HttpStatus.BAD_REQUEST, "목표 기부 금액을 넘어서지 못했습니다."),
+    FUNDING_IS_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "펀딩이 종료되지 않았습니다."),
 
     // 401: UNAUTHORIZED (인증 실패)
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
@@ -59,6 +61,8 @@ public enum ErrorCode {
     CAT_NOT_FOUND(HttpStatus.NOT_FOUND, "고양이를 찾을 수 없습니다."),
     DONATION_NOT_FOUND(HttpStatus.NOT_FOUND, "기부 내역을 찾을 수 없습니다."),
     FRIENDSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "친구 관계를 찾을 수 없습니다."),
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
+    INCLUDE_NOT_UPLOADED_FILE(HttpStatus.NOT_FOUND, "서버에 업로드되지 않은 파일이 포함되어 있습니다."),
 
     // 409: CONFLICT (중복된 요청)
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),

--- a/src/main/java/com/chaeum/api/global/file/controller/FileController.java
+++ b/src/main/java/com/chaeum/api/global/file/controller/FileController.java
@@ -37,8 +37,8 @@ public class FileController {
         return ApiResponse.success(fileUploadResponse);
     }
 
-    @Operation(summary = "펀딩 사진 업로드", description = "[DONOR 이상 가능]")
-    @PreAuthorize("hasRole('DONOR')")
+    @Operation(summary = "펀딩 사진 업로드", description = "[RECIPIENT 이상 가능]")
+    @PreAuthorize("hasRole('RECIPIENT')")
     @PostMapping(
         value = "/funding",
         consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
@@ -48,6 +48,20 @@ public class FileController {
         @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles
     ) {
         List<FileUploadResponse> fileUploadResponses = fileService.uploadFiles(multipartFiles, "funding/");
+        return ApiResponse.success(fileUploadResponses);
+    }
+
+    @Operation(summary = "펀딩 후기 사진 업로드", description = "[RECIPIENT 이상 가능]")
+    @PreAuthorize("hasRole('RECIPIENT')")
+    @PostMapping(
+        value = "/review",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ApiResponse<List<FileUploadResponse>> uploadReviewImage(
+        @RequestParam(name = "multipartFile") List<MultipartFile> multipartFiles
+    ) {
+        List<FileUploadResponse> fileUploadResponses = fileService.uploadFiles(multipartFiles, "review/");
         return ApiResponse.success(fileUploadResponses);
     }
 }

--- a/src/main/java/com/chaeum/api/global/file/dto/ExternalFileResponse.java
+++ b/src/main/java/com/chaeum/api/global/file/dto/ExternalFileResponse.java
@@ -1,0 +1,31 @@
+package com.chaeum.api.global.file.dto;
+
+import com.chaeum.api.global.file.entity.UploadedFile;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExternalFileResponse {
+
+    private String fileUrl;
+
+    private Long fileSize;
+
+    private String contentType;
+
+    public static ExternalFileResponse toDto(UploadedFile uploadedFile) {
+        return ExternalFileResponse.builder()
+            .fileUrl(uploadedFile.getFileUrl())
+            .fileSize(uploadedFile.getFileSize())
+            .contentType(uploadedFile.getContentType())
+            .build();
+    }
+
+    public static List<ExternalFileResponse> toListDto(List<UploadedFile> uploadedFiles) {
+        return uploadedFiles.stream()
+            .map(ExternalFileResponse::toDto)
+            .toList();
+    }
+}

--- a/src/main/java/com/chaeum/api/global/file/repository/FileRepository.java
+++ b/src/main/java/com/chaeum/api/global/file/repository/FileRepository.java
@@ -1,9 +1,15 @@
 package com.chaeum.api.global.file.repository;
 
 import com.chaeum.api.global.file.entity.UploadedFile;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FileRepository extends JpaRepository<UploadedFile, Long> {
+
+    Optional<UploadedFile> findByFileUrl(String fileUrl);
+
+    List<UploadedFile> findAllByFileUrlIn(List<String> fileUrls);
 }

--- a/src/main/java/com/chaeum/api/global/file/service/FileService.java
+++ b/src/main/java/com/chaeum/api/global/file/service/FileService.java
@@ -1,5 +1,7 @@
 package com.chaeum.api.global.file.service;
 
+import com.chaeum.api.global.exception.ChaeumException;
+import com.chaeum.api.global.exception.ErrorCode;
 import com.chaeum.api.global.file.dto.FileUploadResponse;
 import com.chaeum.api.global.file.dto.FileUploadResult;
 import com.chaeum.api.global.file.entity.UploadedFile;
@@ -26,6 +28,18 @@ public class FileService {
             fileUploadResponses.add(fileUploadResponse);
         }
         return fileUploadResponses;
+    }
+
+    @Transactional(readOnly = true)
+    public List<UploadedFile> getUploadedFilesByUrls(List<String> fileUrls) {
+        if (fileUrls == null || fileUrls.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<UploadedFile> uploadedFiles = fileRepository.findAllByFileUrlIn(fileUrls);
+        if (uploadedFiles.size() != fileUrls.size()) {
+            throw ChaeumException.from(ErrorCode.INCLUDE_NOT_UPLOADED_FILE);
+        }
+        return uploadedFiles;
     }
 
     public FileUploadResponse uploadFile(MultipartFile file, String folder) {


### PR DESCRIPTION
## ⭐️ Overview

> #83 

펀딩 후기 CRUD를 구현했습니다.

## 🔧 Tasks

- 펀딩 후기 등록
- 펀딩 후기 상세 조회
- 펀딩 후기 목록 최신순 조회
- 펀딩 후기 변경
- 펀딩 후기 삭제

## 📝 Additional Notes

1. 멤버 생성시 포인트가 null로 설정되어있는 문제를 해결했습니다.
2. 파일 조회 DTO를 만들었습니다.
3. URL로 파일을 조회할 수 있는 메서드를 구현했습니다. 사진 업로드가 필요한 도메인에서 사용 바랍니다.

## 📸 Screenshot

- 리뷰 이미지 저장
<img width="271" alt="스크린샷 2025-04-12 오전 12 50 16" src="https://github.com/user-attachments/assets/0abf90c9-748f-480e-a905-e708430597a1" />

- 리뷰 상세 조회
<img width="262" alt="스크린샷 2025-04-12 오전 12 57 20" src="https://github.com/user-attachments/assets/f3a7a36c-50f8-4d35-9320-7521750a4611" />

- 리뷰 목록 조회
<img width="274" alt="스크린샷 2025-04-12 오전 12 57 53" src="https://github.com/user-attachments/assets/35b21acf-9cdc-4481-b065-fdc354b5cc05" />

- 리뷰 삭제
<img width="257" alt="스크린샷 2025-04-12 오전 12 59 13" src="https://github.com/user-attachments/assets/adc61552-8027-4226-a98c-f1bcc281ccd3" />