### PR TITLE
feat: 미션 기능 API 구현 완료

### DIFF
--- a/src/main/java/com/chaeum/api/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/chaeum/api/domain/mission/controller/MissionController.java
@@ -50,14 +50,10 @@ public class MissionController {
         return ApiResponse.success(missionResponse);
     }
 
-    @Operation(
-        summary = "조건별 미션 조회",
-        description = """
-            모든 Role 조회 가능<br>
-            조건을 하나라도 입력하지 않으면 전체 조회됨<br>
-            """
-    )
-    @PreAuthorize("hasRole('DONOR')")
+    // 내 미션 조회 컨트롤러 구현
+
+    @Operation(summary = "조건별 미션 조회", description = "ADMIN 이상 조회 가능")
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/condition")
     public ApiResponse<IdCursorResult<MissionResponse>> getMissionsByCondition(
         @RequestParam(name = "missionName", required = false) String missionName,

--- a/src/main/java/com/chaeum/api/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/chaeum/api/domain/mission/controller/MissionController.java
@@ -1,4 +1,96 @@
 package com.chaeum.api.domain.mission.controller;
 
+import com.chaeum.api.domain.mission.dto.request.MissionCreateRequest;
+import com.chaeum.api.domain.mission.dto.request.MissionUpdateRequest;
+import com.chaeum.api.domain.mission.dto.response.MissionResponse;
+import com.chaeum.api.domain.mission.entity.MissionType;
+import com.chaeum.api.domain.mission.service.MissionService;
+import com.chaeum.api.global.pagination.cursorResult.IdCursorResult;
+import com.chaeum.api.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mission")
+@Tag(name = "Mission", description = "미션 관리")
 public class MissionController {
+
+    private final MissionService missionService;
+
+    @Operation(summary = "미션 추가", description = "ADMIN 이상 추가 가능")
+    // @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('DONOR')")
+    @PostMapping("")
+    public ApiResponse<Long> save(
+        @Valid @RequestBody MissionCreateRequest missionCreateRequest
+    ) {
+        Long id = missionService.save(missionCreateRequest);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(summary = "미션 개별 조회", description = "모든 Role 조회 가능")
+    @PreAuthorize("hasRole('DONOR')")
+    @GetMapping("")
+    public ApiResponse<MissionResponse> getMission(
+        @RequestParam(name = "missionId") Long missionId
+    ) {
+        MissionResponse missionResponse = missionService.getMission(missionId);
+        return ApiResponse.success(missionResponse);
+    }
+
+    @Operation(
+        summary = "조건별 미션 조회",
+        description = """
+            모든 Role 조회 가능<br>
+            조건을 하나라도 입력하지 않으면 전체 조회됨<br>
+            """
+    )
+    @PreAuthorize("hasRole('DONOR')")
+    @GetMapping("/condition")
+    public ApiResponse<IdCursorResult<MissionResponse>> getMissionsByCondition(
+        @RequestParam(name = "missionName", required = false) String missionName,
+        @RequestParam(name = "missionType", required = false) MissionType missionType,
+        @RequestParam(name = "cursor", required = false) Long cursor,
+        @RequestParam(name = "limit", defaultValue = "3") int limit
+    ) {
+        IdCursorResult<MissionResponse> missions = missionService.getMissionsByCondition(
+            missionName, missionType, cursor, limit);
+        return ApiResponse.success(missions);
+    }
+
+    @Operation(summary = "미션 수정", description = "ADMIN 이상 수정 가능")
+    // @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('DONOR')")
+    @PatchMapping("")
+    public ApiResponse<Long> updateStatus(
+        @RequestParam(name = "missionId") Long missionId,
+        @Valid @RequestBody MissionUpdateRequest missionUpdateRequest
+    ) {
+        Long id = missionService.update(missionId, missionUpdateRequest);
+        return ApiResponse.success(id);
+    }
+
+    @Operation(summary = "미션 삭제", description = "ADMIN 이상 삭제 가능")
+    // @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('DONOR')")
+    @DeleteMapping("/{missionId}")
+    public ApiResponse<Long> delete(
+        @PathVariable(name = "missionId") Long missionId
+    ) {
+        Long id = missionService.delete(missionId);
+        return ApiResponse.success(id);
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/chaeum/api/domain/mission/controller/MissionController.java
@@ -31,8 +31,7 @@ public class MissionController {
     private final MissionService missionService;
 
     @Operation(summary = "미션 추가", description = "ADMIN 이상 추가 가능")
-    // @PreAuthorize("hasRole('ADMIN')")
-    @PreAuthorize("hasRole('DONOR')")
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("")
     public ApiResponse<Long> save(
         @Valid @RequestBody MissionCreateRequest missionCreateRequest
@@ -72,8 +71,7 @@ public class MissionController {
     }
 
     @Operation(summary = "미션 수정", description = "ADMIN 이상 수정 가능")
-    // @PreAuthorize("hasRole('ADMIN')")
-    @PreAuthorize("hasRole('DONOR')")
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("")
     public ApiResponse<Long> updateStatus(
         @RequestParam(name = "missionId") Long missionId,
@@ -84,8 +82,7 @@ public class MissionController {
     }
 
     @Operation(summary = "미션 삭제", description = "ADMIN 이상 삭제 가능")
-    // @PreAuthorize("hasRole('ADMIN')")
-    @PreAuthorize("hasRole('DONOR')")
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{missionId}")
     public ApiResponse<Long> delete(
         @PathVariable(name = "missionId") Long missionId

--- a/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionCreateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionCreateRequest.java
@@ -1,6 +1,5 @@
 package com.chaeum.api.domain.mission.dto.request;
 
-import com.chaeum.api.domain.mission.entity.MissionStatus;
 import com.chaeum.api.domain.mission.entity.MissionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -22,10 +21,6 @@ public class MissionCreateRequest {
     @NotNull
     @Schema(description = "미션 사진 URL", example = "https://bucket.s3.ap-northeast-2.amazonaw.com/item/mission-image.png")
     private String missionImageUrl;
-
-    @NotNull
-    @Schema(description = "미션 상태", example = "PENDING")
-    private MissionStatus status;
 
     @NotNull
     @Schema(description = "미션 종류", example = "CHECK_IN")

--- a/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionCreateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionCreateRequest.java
@@ -1,0 +1,33 @@
+package com.chaeum.api.domain.mission.dto.request;
+
+import com.chaeum.api.domain.mission.entity.MissionStatus;
+import com.chaeum.api.domain.mission.entity.MissionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MissionCreateRequest {
+
+    @NotNull
+    @Schema(description = "미션 이름", example = "오늘의 출석 체크")
+    private String name;
+
+    @NotNull
+    @Schema(description = "미션 설명", example = "오늘도 출석해서 고양이를 돌봐주세요!")
+    private String description;
+
+    @NotNull
+    @Schema(description = "미션 사진 URL", example = "https://bucket.s3.ap-northeast-2.amazonaw.com/item/mission-image.png")
+    private String missionImageUrl;
+
+    @NotNull
+    @Schema(description = "미션 상태", example = "PENDING")
+    private MissionStatus status;
+
+    @NotNull
+    @Schema(description = "미션 종류", example = "CHECK_IN")
+    private MissionType type;
+}

--- a/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionCreateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionCreateRequest.java
@@ -3,6 +3,7 @@ package com.chaeum.api.domain.mission.dto.request;
 import com.chaeum.api.domain.mission.entity.MissionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,10 +12,12 @@ import lombok.Setter;
 public class MissionCreateRequest {
 
     @NotNull
+    @Size(min = 1, max = 200)
     @Schema(description = "미션 이름", example = "오늘의 출석 체크")
     private String name;
 
     @NotNull
+    @Size(min = 1, max = 500)
     @Schema(description = "미션 설명", example = "오늘도 출석해서 고양이를 돌봐주세요!")
     private String description;
 

--- a/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionUpdateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionUpdateRequest.java
@@ -1,0 +1,33 @@
+package com.chaeum.api.domain.mission.dto.request;
+
+import com.chaeum.api.domain.mission.entity.MissionStatus;
+import com.chaeum.api.domain.mission.entity.MissionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MissionUpdateRequest {
+
+    @NotNull
+    @Schema(description = "미션 이름", example = "오늘의 출석 체크")
+    private String name;
+
+    @NotNull
+    @Schema(description = "미션 설명", example = "오늘도 출석해서 고양이를 돌봐주세요!")
+    private String description;
+
+    @NotNull
+    @Schema(description = "미션 사진 URL", example = "https://bucket.s3.ap-northeast-2.amazonaw.com/item/mission-image.png")
+    private String missionImage;
+
+    @NotNull
+    @Schema(description = "미션 상태", example = "IN_PROGRESS")
+    private MissionStatus status;
+
+    @NotNull
+    @Schema(description = "미션 유형", example = "CHECK_IN")
+    private MissionType type;
+}

--- a/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionUpdateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.chaeum.api.domain.mission.dto.request;
 
-import com.chaeum.api.domain.mission.entity.MissionStatus;
 import com.chaeum.api.domain.mission.entity.MissionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -22,10 +21,6 @@ public class MissionUpdateRequest {
     @NotNull
     @Schema(description = "미션 사진 URL", example = "https://bucket.s3.ap-northeast-2.amazonaw.com/item/mission-image.png")
     private String missionImage;
-
-    @NotNull
-    @Schema(description = "미션 상태", example = "IN_PROGRESS")
-    private MissionStatus status;
 
     @NotNull
     @Schema(description = "미션 유형", example = "CHECK_IN")

--- a/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionUpdateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionUpdateRequest.java
@@ -3,6 +3,7 @@ package com.chaeum.api.domain.mission.dto.request;
 import com.chaeum.api.domain.mission.entity.MissionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,10 +12,12 @@ import lombok.Setter;
 public class MissionUpdateRequest {
 
     @NotNull
+    @Size(min = 1, max = 200)
     @Schema(description = "미션 이름", example = "오늘의 출석 체크")
     private String name;
 
     @NotNull
+    @Size(min = 1, max = 500)
     @Schema(description = "미션 설명", example = "오늘도 출석해서 고양이를 돌봐주세요!")
     private String description;
 

--- a/src/main/java/com/chaeum/api/domain/mission/dto/response/MissionResponse.java
+++ b/src/main/java/com/chaeum/api/domain/mission/dto/response/MissionResponse.java
@@ -1,7 +1,6 @@
 package com.chaeum.api.domain.mission.dto.response;
 
 import com.chaeum.api.domain.mission.entity.Mission;
-import com.chaeum.api.domain.mission.entity.MissionStatus;
 import com.chaeum.api.global.pagination.provider.IdProvider;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,15 +17,12 @@ public class MissionResponse implements IdProvider {
 
     private String missionImage;
 
-    private MissionStatus status;
-
     public static MissionResponse toDto(Mission mission) {
         return MissionResponse.builder()
             .id(mission.getId())
             .name(mission.getName())
             .description(mission.getDescription())
             .missionImage(mission.getMissionImageUrl())
-            .status(mission.getStatus())
             .build();
     }
 }

--- a/src/main/java/com/chaeum/api/domain/mission/dto/response/MissionResponse.java
+++ b/src/main/java/com/chaeum/api/domain/mission/dto/response/MissionResponse.java
@@ -1,0 +1,32 @@
+package com.chaeum.api.domain.mission.dto.response;
+
+import com.chaeum.api.domain.mission.entity.Mission;
+import com.chaeum.api.domain.mission.entity.MissionStatus;
+import com.chaeum.api.global.pagination.provider.IdProvider;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MissionResponse implements IdProvider {
+
+    private Long id;
+
+    private String name;
+
+    private String description;
+
+    private String missionImage;
+
+    private MissionStatus status;
+
+    public static MissionResponse toDto(Mission mission) {
+        return MissionResponse.builder()
+            .id(mission.getId())
+            .name(mission.getName())
+            .description(mission.getDescription())
+            .missionImage(mission.getMissionImageUrl())
+            .status(mission.getStatus())
+            .build();
+    }
+}

--- a/src/main/java/com/chaeum/api/domain/mission/entity/Mission.java
+++ b/src/main/java/com/chaeum/api/domain/mission/entity/Mission.java
@@ -55,7 +55,6 @@ public class Mission extends BaseEntity {
             .name(missionCreateRequest.getName())
             .missionImageUrl(missionCreateRequest.getMissionImageUrl())
             .description(missionCreateRequest.getDescription())
-            .status(MissionStatus.IN_PROGRESS)
             .type(missionCreateRequest.getType())
             .build();
     }

--- a/src/main/java/com/chaeum/api/domain/mission/entity/Mission.java
+++ b/src/main/java/com/chaeum/api/domain/mission/entity/Mission.java
@@ -1,4 +1,70 @@
 package com.chaeum.api.domain.mission.entity;
 
-public class Mission {
+import com.chaeum.api.domain.mission.dto.request.MissionCreateRequest;
+import com.chaeum.api.domain.mission.dto.request.MissionUpdateRequest;
+import com.chaeum.api.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "mission")
+public class Mission extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mission_id")
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "mission_image_url", nullable = false)
+    private String missionImageUrl;
+
+    @Column(name = "description", columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mission_status", nullable = false)
+    private MissionStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mission_type", nullable = false)
+    private MissionType type;
+
+    public static Mission toEntity(MissionCreateRequest missionCreateRequest) {
+        return Mission.builder()
+            .name(missionCreateRequest.getName())
+            .missionImageUrl(missionCreateRequest.getMissionImageUrl())
+            .description(missionCreateRequest.getDescription())
+            .status(missionCreateRequest.getStatus())
+            .type(missionCreateRequest.getType())
+            .build();
+    }
+
+    public void update(MissionUpdateRequest missionUpdateRequest) {
+        Optional.ofNullable(missionUpdateRequest.getName()).ifPresent(this::setName);
+        Optional.ofNullable(missionUpdateRequest.getMissionImage()).ifPresent(this::setMissionImageUrl);
+        Optional.ofNullable(missionUpdateRequest.getDescription()).ifPresent(this::setDescription);
+        Optional.ofNullable(missionUpdateRequest.getStatus()).ifPresent(this::setStatus);
+        Optional.ofNullable(missionUpdateRequest.getType()).ifPresent(this::setType);
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/mission/entity/Mission.java
+++ b/src/main/java/com/chaeum/api/domain/mission/entity/Mission.java
@@ -43,10 +43,6 @@ public class Mission extends BaseEntity {
     private String description;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "mission_status", nullable = false)
-    private MissionStatus status;
-
-    @Enumerated(EnumType.STRING)
     @Column(name = "mission_type", nullable = false)
     private MissionType type;
 

--- a/src/main/java/com/chaeum/api/domain/mission/entity/Mission.java
+++ b/src/main/java/com/chaeum/api/domain/mission/entity/Mission.java
@@ -55,7 +55,7 @@ public class Mission extends BaseEntity {
             .name(missionCreateRequest.getName())
             .missionImageUrl(missionCreateRequest.getMissionImageUrl())
             .description(missionCreateRequest.getDescription())
-            .status(missionCreateRequest.getStatus())
+            .status(MissionStatus.IN_PROGRESS)
             .type(missionCreateRequest.getType())
             .build();
     }
@@ -64,7 +64,6 @@ public class Mission extends BaseEntity {
         Optional.ofNullable(missionUpdateRequest.getName()).ifPresent(this::setName);
         Optional.ofNullable(missionUpdateRequest.getMissionImage()).ifPresent(this::setMissionImageUrl);
         Optional.ofNullable(missionUpdateRequest.getDescription()).ifPresent(this::setDescription);
-        Optional.ofNullable(missionUpdateRequest.getStatus()).ifPresent(this::setStatus);
         Optional.ofNullable(missionUpdateRequest.getType()).ifPresent(this::setType);
     }
 }

--- a/src/main/java/com/chaeum/api/domain/mission/entity/MissionStatus.java
+++ b/src/main/java/com/chaeum/api/domain/mission/entity/MissionStatus.java
@@ -1,0 +1,18 @@
+package com.chaeum.api.domain.mission.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MissionStatus {
+
+    PENDING("PENDING", "대기 중"),
+    IN_PROGRESS("IN_PROGRESS", "진행 중"),
+    COMPLETED("COMPLETED", "완료됨"),
+    FAILED("FAILED", "실패함"),
+    CANCELED("CANCELED", "취소됨");
+
+    private final String key;
+    private final String description;
+}

--- a/src/main/java/com/chaeum/api/domain/mission/entity/MissionType.java
+++ b/src/main/java/com/chaeum/api/domain/mission/entity/MissionType.java
@@ -1,0 +1,17 @@
+package com.chaeum.api.domain.mission.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MissionType {
+
+    CHECK_IN("CHECK_IN", "출석 미션"),
+    DONATION("DONATION", "기부 미션"),
+    REFERRAL("REFERRAL", "친구 초대 미션"),
+    CUSTOM("CUSTOM", "커스텀 미션");
+
+    private final String key;
+    private final String description;
+}

--- a/src/main/java/com/chaeum/api/domain/mission/repository/MissionRepository.java
+++ b/src/main/java/com/chaeum/api/domain/mission/repository/MissionRepository.java
@@ -1,4 +1,10 @@
 package com.chaeum.api.domain.mission.repository;
 
-public interface MissionRepository {
+import com.chaeum.api.domain.mission.entity.Mission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+
 }

--- a/src/main/java/com/chaeum/api/domain/mission/service/MissionService.java
+++ b/src/main/java/com/chaeum/api/domain/mission/service/MissionService.java
@@ -35,6 +35,8 @@ public class MissionService {
         return MissionResponse.toDto(mission);
     }
 
+    // 내 미션들만 볼 수 있는 서비스 로직 작성
+
     @Transactional(readOnly = true)
     public IdCursorResult<MissionResponse> getMissionsByCondition(String missionName, MissionType missionType,
         Long cursor, int limit) {

--- a/src/main/java/com/chaeum/api/domain/mission/service/MissionService.java
+++ b/src/main/java/com/chaeum/api/domain/mission/service/MissionService.java
@@ -1,4 +1,74 @@
 package com.chaeum.api.domain.mission.service;
 
+import com.chaeum.api.domain.mission.dto.request.MissionCreateRequest;
+import com.chaeum.api.domain.mission.dto.request.MissionUpdateRequest;
+import com.chaeum.api.domain.mission.dto.response.MissionResponse;
+import com.chaeum.api.domain.mission.entity.Mission;
+import com.chaeum.api.domain.mission.entity.MissionType;
+import com.chaeum.api.domain.mission.repository.MissionRepository;
+import com.chaeum.api.global.exception.ChaeumException;
+import com.chaeum.api.global.exception.ErrorCode;
+import com.chaeum.api.global.pagination.cursorResult.IdCursorResult;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class MissionService {
+
+    private final MissionRepository missionRepository;
+
+    @Transactional
+    public Long save(MissionCreateRequest missionCreateRequest) {
+        Mission mission = Mission.toEntity(missionCreateRequest);
+        missionRepository.save(mission);
+        return mission.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public MissionResponse getMission(Long missionId) {
+        Mission mission = findById(missionId);
+        return MissionResponse.toDto(mission);
+    }
+
+    @Transactional(readOnly = true)
+    public IdCursorResult<MissionResponse> getMissionsByCondition(String missionName, MissionType missionType,
+        Long cursor, int limit) {
+        List<Mission> missions = missionRepository.findAll();
+        List<Mission> filteredMissions = missions.stream()
+            .filter(mission -> (missionName == null || missionName.trim().isEmpty()) ||
+                mission.getName().toLowerCase().contains(missionName.toLowerCase()))
+            .filter(mission -> missionType == null || mission.getType() == missionType)
+            .filter(mission -> cursor == null || mission.getId() > cursor)
+            .sorted(Comparator.comparingLong(Mission::getId))
+            .collect(Collectors.toList());
+
+        List<MissionResponse> missionsByName = filteredMissions.stream()
+            .map(MissionResponse::toDto)
+            .collect(Collectors.toList());
+
+        return IdCursorResult.of(missionsByName, cursor, limit);
+    }
+
+    @Transactional
+    public Long update(Long missionId, MissionUpdateRequest missionUpdateRequest) {
+        Mission mission = findById(missionId);
+        mission.update(missionUpdateRequest);
+        return mission.getId();
+    }
+
+    @Transactional
+    public Long delete(Long missionId) {
+        missionRepository.deleteById(missionId);
+        return missionId;
+    }
+
+    private Mission findById(Long missionId) {
+        return missionRepository.findById(missionId)
+            .orElseThrow(() -> ChaeumException.from(ErrorCode.MISSION_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/missionProgress/entity/MissionProgress.java
+++ b/src/main/java/com/chaeum/api/domain/missionProgress/entity/MissionProgress.java
@@ -5,6 +5,8 @@ import com.chaeum.api.domain.mission.entity.Mission;
 import com.chaeum.api.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -39,6 +41,10 @@ public class MissionProgress extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mission_id", nullable = false)
     private Mission mission;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mission_status", nullable = false)
+    private MissionStatus status;
 
     @Column(name = "current_count", nullable = false)
     private int currentCount;

--- a/src/main/java/com/chaeum/api/domain/missionProgress/entity/MissionProgress.java
+++ b/src/main/java/com/chaeum/api/domain/missionProgress/entity/MissionProgress.java
@@ -1,9 +1,16 @@
 package com.chaeum.api.domain.missionProgress.entity;
 
+import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.domain.mission.entity.Mission;
+import com.chaeum.api.global.entity.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,9 +26,23 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "mission_progress")
-public class MissionProgress {
+public class MissionProgress extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @Column(name = "current_count", nullable = false)
+    private int currentCount;
+
+    @Column(name = "progress_count", nullable = false)
+    private int progressCount;
 }

--- a/src/main/java/com/chaeum/api/domain/missionProgress/entity/MissionStatus.java
+++ b/src/main/java/com/chaeum/api/domain/missionProgress/entity/MissionStatus.java
@@ -1,4 +1,4 @@
-package com.chaeum.api.domain.mission.entity;
+package com.chaeum.api.domain.missionProgress.entity;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode {
     INCLUDE_NOT_UPLOADED_FILE(HttpStatus.NOT_FOUND, "서버에 업로드되지 않은 파일이 포함되어 있습니다."),
     ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "출석 정보를 찾을 수 없습니다."),
     TITLE_NOT_FOUND(HttpStatus.NOT_FOUND, "칭호를 찾을 수 없습니다."),
+    MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "미션을 찾을 수 없습니다."),
 
     // 409: CONFLICT (중복된 요청)
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),

--- a/src/main/java/com/chaeum/api/global/file/controller/FileController.java
+++ b/src/main/java/com/chaeum/api/global/file/controller/FileController.java
@@ -23,6 +23,20 @@ public class FileController {
 
     private final FileService fileService;
 
+    @Operation(summary = "미션 사진 업로드", description = "[ADMIN 이상 가능]")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping(
+        value = "/mission",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ApiResponse<FileUploadResponse> uploadMissionImage(
+        @RequestParam(name = "multipartFile") MultipartFile multipartFile
+    ) {
+        FileUploadResponse fileUploadResponse = fileService.uploadFile(multipartFile, "mission/");
+        return ApiResponse.success(fileUploadResponse);
+    }
+
     @Operation(summary = "아이템 사진 업로드", description = "[ADMIN 이상 가능]")
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping(


### PR DESCRIPTION
## ⭐️ Overview

> #88

미션 기능 API를 구현했습니다.

## 🔧 Tasks

- 미션 생성
- 개별 미션 조회
- 조건별 미션 조회
- 미션 수정
- 미션 삭제

## 📝 Additional Notes
  
- `Title` 엔티티와의 혼동 방지 및 필드명 일관성을 고려하여, ERD에 설계된 `title` 필드를 `name`으로 변경했습니다.
- 향후 미션별 행위에 따른 분기 처리 및 확장을 위해 `MissionType` enum 필드를 도입했습니다.
- 초기 정의된 미션 타입: `CHECK_IN`(출석), `DONATION`(기부), `REFERRAL`(친구 초대), `CUSTOM`(커스텀)

## 📸 Screenshot

- **미션 생성**

  <img src="https://github.com/user-attachments/assets/dec9fb97-b350-43d7-baaf-7b9cbedfebbe" width="700"/>

- **개별 미션 조회**

  <img src="https://github.com/user-attachments/assets/261941a8-f6c2-4455-80fc-6b02f36e7cbe" width="700"/>

- **조건별 미션 조회 - '기부'라는 이름으로 검색**

  <img src="https://github.com/user-attachments/assets/47c04055-1a89-4bf0-bb13-28128477a085" width="700"/>

- **조건별 미션 조회 - 전체 조회**

  <img src="https://github.com/user-attachments/assets/34b9bd44-c9d8-42ff-ae4a-4c0efd22702d" width="700"/>

- **미션 수정**

  <img src="https://github.com/user-attachments/assets/d138f99d-c9dc-4bb4-a37c-29a8a13c1df5" width="700"/>

- **미션 수정 결과 (완료된 모습)**

  <img src="https://github.com/user-attachments/assets/82fcff71-0f00-4833-ac32-933d6049774a" width="700"/>

- **미션 삭제**

  <img src="https://github.com/user-attachments/assets/343c871e-b2fa-451b-8b16-aa18de555096" width="700"/>
