### PR TITLE
feat: 회원별 미션 기능 구현 완료

### DIFF
--- a/src/main/java/com/chaeum/api/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/chaeum/api/domain/attendance/service/AttendanceService.java
@@ -3,6 +3,8 @@ package com.chaeum.api.domain.attendance.service;
 import com.chaeum.api.domain.attendance.entity.Attendance;
 import com.chaeum.api.domain.attendance.repository.AttendanceRepository;
 import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.domain.memberMission.service.MemberMissionService;
+import com.chaeum.api.domain.mission.entity.MissionType;
 import com.chaeum.api.global.auth.util.LoginMemberProvider;
 import com.chaeum.api.global.exception.ChaeumException;
 import com.chaeum.api.global.exception.ErrorCode;
@@ -19,6 +21,7 @@ public class AttendanceService {
 
     private final AttendanceRepository attendanceRepository;
     private final LoginMemberProvider loginMemberProvider;
+    private final MemberMissionService memberMissionService;
 
     @Transactional
     public Long save() {
@@ -27,7 +30,9 @@ public class AttendanceService {
         validateDate(today);
         validateDuplicateAttendance(member, today);
         Attendance attendance = Attendance.create(member, today);
-        return attendanceRepository.save(attendance).getId();
+        Long id = attendanceRepository.save(attendance).getId();
+        memberMissionService.increaseProgressByType(MissionType.ATTENDANCE);
+        return id;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/chaeum/api/domain/cat/service/CatService.java
+++ b/src/main/java/com/chaeum/api/domain/cat/service/CatService.java
@@ -11,7 +11,6 @@ import com.chaeum.api.global.exception.ChaeumException;
 import com.chaeum.api.global.exception.ErrorCode;
 
 import java.math.BigInteger;
-import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,11 +32,11 @@ public class CatService {
     }
 
     @Transactional
-    public List<Integer> addExperience(BigInteger gainedExp) {
+    public void addExperience(BigInteger gainedExp) {
         Long memberId = loginMemberProvider.getCurrentLoginMemberId();
         Cat cat = findByMemberId(memberId);
         memberMissionService.increaseProgressByType(MissionType.CAT_EXP);
-        return cat.addExpAndGetLevelUps(gainedExp);
+        cat.addExpAndGetLevelUps(gainedExp);
     }
 
     @Transactional

--- a/src/main/java/com/chaeum/api/domain/cat/service/CatService.java
+++ b/src/main/java/com/chaeum/api/domain/cat/service/CatService.java
@@ -4,6 +4,8 @@ import com.chaeum.api.domain.cat.dto.response.CatInformationResponse;
 import com.chaeum.api.domain.cat.entity.Cat;
 import com.chaeum.api.domain.cat.repository.CatRepository;
 import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.domain.memberMission.service.MemberMissionService;
+import com.chaeum.api.domain.mission.entity.MissionType;
 import com.chaeum.api.global.auth.util.LoginMemberProvider;
 import com.chaeum.api.global.exception.ChaeumException;
 import com.chaeum.api.global.exception.ErrorCode;
@@ -21,6 +23,7 @@ public class CatService {
 
     private final CatRepository catRepository;
     private final LoginMemberProvider loginMemberProvider;
+    private final MemberMissionService memberMissionService;
 
     @Transactional(readOnly = true)
     public CatInformationResponse getMyCatInformation() {
@@ -33,6 +36,7 @@ public class CatService {
     public List<Integer> addExperience(BigInteger gainedExp) {
         Long memberId = loginMemberProvider.getCurrentLoginMemberId();
         Cat cat = findByMemberId(memberId);
+        memberMissionService.increaseProgressByType(MissionType.CAT_EXP);
         return cat.addExpAndGetLevelUps(gainedExp);
     }
 
@@ -44,6 +48,6 @@ public class CatService {
 
     public Cat findByMemberId(Long memberId) {
         return catRepository.findByMemberId(memberId)
-                .orElseThrow(() -> ChaeumException.from(ErrorCode.CAT_NOT_FOUND));
+            .orElseThrow(() -> ChaeumException.from(ErrorCode.CAT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
+++ b/src/main/java/com/chaeum/api/domain/donation/service/DonationService.java
@@ -9,6 +9,8 @@ import com.chaeum.api.domain.donation.repository.DonationRepository;
 import com.chaeum.api.domain.funding.entity.Funding;
 import com.chaeum.api.domain.funding.service.FundingService;
 import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.domain.memberMission.service.MemberMissionService;
+import com.chaeum.api.domain.mission.entity.MissionType;
 import com.chaeum.api.domain.title.service.TitleService;
 import com.chaeum.api.global.auth.util.LoginMemberProvider;
 import com.chaeum.api.global.exception.ChaeumException;
@@ -30,6 +32,7 @@ public class DonationService {
     private final LoginMemberProvider loginMemberProvider;
     private final TitleService titleService;
     private final ApplicationEventPublisher eventPublisher;
+    private final MemberMissionService memberMissionService;
 
     @Transactional
     public DonationCreateResponse save(DonationCreateRequest request) {
@@ -39,11 +42,12 @@ public class DonationService {
         Funding funding = fundingService.findById(request.getFundingId());
         Donation donation = Donation.toEntity(request, member, funding);
         Donation savedDonation = donationRepository.save(donation);
+
+        memberMissionService.increaseProgressByType(MissionType.DONATION);
+        titleService.giveTitle(getDonationCountByMember(member));
         eventPublisher.publishEvent(
             DonationEvent.from(savedDonation, member, funding.getMember())
         );
-
-        titleService.giveTitle(getDonationCountByMember(member));
 
         return DonationCreateResponse.toDto(savedDonation);
     }

--- a/src/main/java/com/chaeum/api/domain/inventory/service/InventoryService.java
+++ b/src/main/java/com/chaeum/api/domain/inventory/service/InventoryService.java
@@ -12,6 +12,8 @@ import com.chaeum.api.domain.item.entity.ItemCategory;
 import com.chaeum.api.domain.item.service.ItemService;
 import com.chaeum.api.domain.member.entity.Member;
 import com.chaeum.api.domain.member.service.MemberService;
+import com.chaeum.api.domain.memberMission.service.MemberMissionService;
+import com.chaeum.api.domain.mission.entity.MissionType;
 import com.chaeum.api.global.auth.util.LoginMemberProvider;
 import com.chaeum.api.global.exception.ChaeumException;
 import com.chaeum.api.global.exception.ErrorCode;
@@ -39,6 +41,7 @@ public class InventoryService {
     private final MemberService memberService;
     private final CatService catService;
     private final ApplicationEventPublisher eventPublisher;
+    private final MemberMissionService memberMissionService;
 
     private static final int DEFAULT_ITEM_QUANTITY = 1;
     private static final int DEFAULT_INTERACTION_ITEM_QUANTITY = 5;
@@ -67,17 +70,17 @@ public class InventoryService {
 
     @Transactional(readOnly = true)
     public CreatedAtCursorResult<InventoryResponse> getInventoriesByCategory(
-            ItemCategory category, LocalDateTime cursor, int limit
+        ItemCategory category, LocalDateTime cursor, int limit
     ) {
         Long memberId = loginMemberProvider.getCurrentLoginMemberId();
         List<Inventory> inventories = findByMemberId(memberId);
 
         List<InventoryResponse> filteredInventories = inventories.stream()
-                .filter(inventory -> inventory.getItem().getCategory() == category)
-                .filter(inventory -> cursor == null || inventory.getCreatedAt().isAfter(cursor))
-                .sorted(Comparator.comparing(Inventory::getCreatedAt))
-                .map(InventoryResponse::toDto)
-                .collect(Collectors.toList());
+            .filter(inventory -> inventory.getItem().getCategory() == category)
+            .filter(inventory -> cursor == null || inventory.getCreatedAt().isAfter(cursor))
+            .sorted(Comparator.comparing(Inventory::getCreatedAt))
+            .map(InventoryResponse::toDto)
+            .collect(Collectors.toList());
 
         return CreatedAtCursorResult.of(filteredInventories, cursor, limit);
     }
@@ -86,12 +89,12 @@ public class InventoryService {
     public List<Long> getWearingInventoryItems() {
         Long memberId = loginMemberProvider.getCurrentLoginMemberId();
         List<Inventory> inventories = inventoryRepository.findByMemberIdAndIsWearing(
-                memberId, true);
+            memberId, true);
         return inventories.stream()
-                .map(Inventory::getItem)
-                .filter(item -> item.isCategoryIn(ItemCategory.DECORATION, ItemCategory.INTERIOR))
-                .map(Item::getId)
-                .toList();
+            .map(Inventory::getItem)
+            .filter(item -> item.isCategoryIn(ItemCategory.DECORATION, ItemCategory.INTERIOR))
+            .map(Item::getId)
+            .toList();
     }
 
     @Transactional
@@ -118,14 +121,15 @@ public class InventoryService {
         inventory.getItem().validateCategory(ItemCategory.INTERACTION);
         inventory.removeQuantity();
         catService.addExperience(ExpConstants.INTERACTION);
+        memberMissionService.increaseProgressByType(MissionType.CAT_INTERACTION);
     }
 
     @Transactional
     public void registerDefaultInteractionItems(Member member) {
         itemService.findByCategory(ItemCategory.INTERACTION).stream()
-                .filter(item -> !inventoryRepository.existsByMemberIdAndItemId(member.getId(), item.getId()))
-                .map(item -> Inventory.create(item, member, DEFAULT_INTERACTION_ITEM_QUANTITY))
-                .forEach(inventoryRepository::save);
+            .filter(item -> !inventoryRepository.existsByMemberIdAndItemId(member.getId(), item.getId()))
+            .map(item -> Inventory.create(item, member, DEFAULT_INTERACTION_ITEM_QUANTITY))
+            .forEach(inventoryRepository::save);
     }
 
     @Transactional(readOnly = true)
@@ -174,7 +178,7 @@ public class InventoryService {
 
     public Inventory findByInventoryId(Long inventoryId) {
         return inventoryRepository.findById(inventoryId)
-                .orElseThrow(() -> ChaeumException.from(ErrorCode.INVENTORY_NOT_FOUND));
+            .orElseThrow(() -> ChaeumException.from(ErrorCode.INVENTORY_NOT_FOUND));
     }
 
     public List<Inventory> findByMemberId(Long memberId) {

--- a/src/main/java/com/chaeum/api/domain/inventory/service/InventoryService.java
+++ b/src/main/java/com/chaeum/api/domain/inventory/service/InventoryService.java
@@ -20,6 +20,7 @@ import com.chaeum.api.global.exception.ErrorCode;
 import com.chaeum.api.global.pagination.cursorResult.CreatedAtCursorResult;
 import com.chaeum.api.global.utils.ExpConstants;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Comparator;
@@ -119,9 +120,10 @@ public class InventoryService {
     public void useInteractionItem(Long inventoryId) {
         Inventory inventory = findByInventoryId(inventoryId);
         inventory.getItem().validateCategory(ItemCategory.INTERACTION);
-        inventory.removeQuantity();
-        catService.addExperience(ExpConstants.INTERACTION);
+        BigInteger exp = ExpConstants.INTERACTION;
+        catService.addExperience(exp);
         memberMissionService.increaseProgressByType(MissionType.CAT_INTERACTION);
+        memberMissionService.increaseProgressByType(MissionType.CAT_EXP, exp);
     }
 
     @Transactional

--- a/src/main/java/com/chaeum/api/domain/member/entity/Member.java
+++ b/src/main/java/com/chaeum/api/domain/member/entity/Member.java
@@ -97,15 +97,6 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Title> titles = List.of();
 
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<MissionProgress> missionProgresses;
-
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Notification> notifications;
-
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Review> reviews;
-
     public void update(MemberUpdateRequest memberUpdateRequest) {
         Optional.ofNullable(memberUpdateRequest.getName()).ifPresent(this::setName);
         Optional.ofNullable(memberUpdateRequest.getProfileImage()).ifPresent(this::setProfileImage);

--- a/src/main/java/com/chaeum/api/domain/memberMission/controller/MemberMissionController.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/controller/MemberMissionController.java
@@ -1,4 +1,35 @@
 package com.chaeum.api.domain.memberMission.controller;
 
+import com.chaeum.api.domain.memberMission.dto.response.MemberMissionResponse;
+import com.chaeum.api.domain.memberMission.service.MemberMissionService;
+import com.chaeum.api.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/member-mission")
+@Tag(name = "MemberMission", description = "회원별 미션 관리")
 public class MemberMissionController {
+
+    private final MemberMissionService memberMissionService;
+
+    @Operation(
+        summary = "내 미션 조회",
+        description = """
+            모든 Role 조회 가능<br>
+            회원별 미션은 5개를 제공하며, 매일 자정에 초기화됩니다.<br>
+            """)
+    @PreAuthorize("hasRole('DONOR')")
+    @GetMapping("")
+    public ApiResponse<List<MemberMissionResponse>> getMemberMission() {
+        List<MemberMissionResponse> missions = memberMissionService.getMemberMissions();
+        return ApiResponse.success(missions);
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/memberMission/controller/MemberMissionController.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/controller/MemberMissionController.java
@@ -1,0 +1,4 @@
+package com.chaeum.api.domain.memberMission.controller;
+
+public class MemberMissionController {
+}

--- a/src/main/java/com/chaeum/api/domain/memberMission/dto/response/MemberMissionResponse.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/dto/response/MemberMissionResponse.java
@@ -1,0 +1,37 @@
+package com.chaeum.api.domain.memberMission.dto.response;
+
+import com.chaeum.api.domain.memberMission.entity.MemberMission;
+import com.chaeum.api.domain.memberMission.entity.MissionStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberMissionResponse {
+
+    private Long missionId;
+
+    private String missionName;
+
+    private String missionDescription;
+
+    private String missionImageUrl;
+
+    private MissionStatus status;
+
+    private int currentCount;
+
+    private int progressCount;
+
+    public static MemberMissionResponse toDto(MemberMission memberMission) {
+        return MemberMissionResponse.builder()
+            .missionId(memberMission.getMission().getId())
+            .missionName(memberMission.getMission().getName())
+            .missionDescription(memberMission.getMission().getDescription())
+            .missionImageUrl(memberMission.getMission().getMissionImageUrl())
+            .status(memberMission.getStatus())
+            .currentCount(memberMission.getCurrentCount())
+            .progressCount(memberMission.getProgressCount())
+            .build();
+    }
+}

--- a/src/main/java/com/chaeum/api/domain/memberMission/entity/MemberMission.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/entity/MemberMission.java
@@ -64,13 +64,14 @@ public class MemberMission extends BaseEntity {
 
     public void reset() {
         this.currentCount = 0;
-        this.status = MissionStatus.PENDING;
+        this.status = MissionStatus.FAILED;
     }
 
     public void increaseProgress() {
         if (isCompleted()) {
             return;
         }
+        updateStatusToInProgress();
         increaseCurrentCount();
         if (isMissionCompleted()) {
             completeMission();
@@ -87,6 +88,12 @@ public class MemberMission extends BaseEntity {
 
     private boolean isMissionCompleted() {
         return this.currentCount >= this.progressCount;
+    }
+
+    private void updateStatusToInProgress() {
+        if (status == MissionStatus.PENDING) {
+            this.status = MissionStatus.IN_PROGRESS;
+        }
     }
 
     private void completeMission() {

--- a/src/main/java/com/chaeum/api/domain/memberMission/entity/MemberMission.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/entity/MemberMission.java
@@ -27,11 +27,12 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "mission_progress")
+@Table(name = "member_mission")
 public class MemberMission extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_mission_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/chaeum/api/domain/memberMission/entity/MemberMission.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/entity/MemberMission.java
@@ -51,4 +51,45 @@ public class MemberMission extends BaseEntity {
 
     @Column(name = "progress_count", nullable = false)
     private int progressCount;
+
+    public static MemberMission create(Member member, Mission mission, int progressCount) {
+        return MemberMission.builder()
+            .member(member)
+            .mission(mission)
+            .status(MissionStatus.PENDING)
+            .currentCount(0)
+            .progressCount(progressCount)
+            .build();
+    }
+
+    public void reset() {
+        this.currentCount = 0;
+        this.status = MissionStatus.PENDING;
+    }
+
+    public void increaseProgress() {
+        if (isCompleted()) {
+            return;
+        }
+        increaseCurrentCount();
+        if (isMissionCompleted()) {
+            completeMission();
+        }
+    }
+
+    private boolean isCompleted() {
+        return this.status == MissionStatus.COMPLETED;
+    }
+
+    private void increaseCurrentCount() {
+        this.currentCount++;
+    }
+
+    private boolean isMissionCompleted() {
+        return this.currentCount >= this.progressCount;
+    }
+
+    private void completeMission() {
+        this.status = MissionStatus.COMPLETED;
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/memberMission/entity/MemberMission.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/entity/MemberMission.java
@@ -63,12 +63,14 @@ public class MemberMission extends BaseEntity {
     }
 
     public void reset() {
-        this.currentCount = 0;
-        this.status = MissionStatus.FAILED;
+        if (!isCompleted()) {
+            this.currentCount = 0;
+            this.status = MissionStatus.FAILED;
+        }
     }
 
     public void increaseProgress() {
-        if (isCompleted()) {
+        if (isCompleted() || isFailed()) {
             return;
         }
         updateStatusToInProgress();
@@ -80,6 +82,10 @@ public class MemberMission extends BaseEntity {
 
     private boolean isCompleted() {
         return this.status == MissionStatus.COMPLETED;
+    }
+
+    private boolean isFailed() {
+        return this.status == MissionStatus.FAILED;
     }
 
     private void increaseCurrentCount() {

--- a/src/main/java/com/chaeum/api/domain/memberMission/entity/MemberMission.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/entity/MemberMission.java
@@ -1,4 +1,4 @@
-package com.chaeum.api.domain.missionProgress.entity;
+package com.chaeum.api.domain.memberMission.entity;
 
 import com.chaeum.api.domain.member.entity.Member;
 import com.chaeum.api.domain.mission.entity.Mission;
@@ -28,7 +28,7 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "mission_progress")
-public class MissionProgress extends BaseEntity {
+public class MemberMission extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/chaeum/api/domain/memberMission/entity/MemberMission.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/entity/MemberMission.java
@@ -63,19 +63,16 @@ public class MemberMission extends BaseEntity {
             .build();
     }
 
-    public void reset() {
-        if (!isCompleted()) {
-            this.currentCount = 0;
-            this.status = MissionStatus.FAILED;
-        }
+    public void increaseProgress() {
+        increaseProgress(1);
     }
 
-    public void increaseProgress() {
-        if (isCompleted() || isFailed()) {
+    public void increaseProgress(int amount) {
+        if (isCompleted()) {
             return;
         }
         updateStatusToInProgress();
-        increaseCurrentCount();
+        increaseCurrentCount(amount);
         if (isMissionCompleted()) {
             completeMission();
         }
@@ -85,12 +82,8 @@ public class MemberMission extends BaseEntity {
         return this.status == MissionStatus.COMPLETED;
     }
 
-    private boolean isFailed() {
-        return this.status == MissionStatus.FAILED;
-    }
-
-    private void increaseCurrentCount() {
-        this.currentCount++;
+    private void increaseCurrentCount(int amount) {
+        this.currentCount += amount;
     }
 
     private boolean isMissionCompleted() {

--- a/src/main/java/com/chaeum/api/domain/memberMission/entity/MissionStatus.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/entity/MissionStatus.java
@@ -9,9 +9,7 @@ public enum MissionStatus {
 
     PENDING("PENDING", "대기 중"),
     IN_PROGRESS("IN_PROGRESS", "진행 중"),
-    COMPLETED("COMPLETED", "완료됨"),
-    FAILED("FAILED", "실패함"),
-    CANCELED("CANCELED", "취소됨");
+    COMPLETED("COMPLETED", "완료됨");
 
     private final String key;
     private final String description;

--- a/src/main/java/com/chaeum/api/domain/memberMission/entity/MissionStatus.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/entity/MissionStatus.java
@@ -1,4 +1,4 @@
-package com.chaeum.api.domain.missionProgress.entity;
+package com.chaeum.api.domain.memberMission.entity;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/chaeum/api/domain/memberMission/repository/MemberMissionRepository.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/repository/MemberMissionRepository.java
@@ -1,4 +1,12 @@
 package com.chaeum.api.domain.memberMission.repository;
 
-public interface MemberMissionRepository {
+import com.chaeum.api.domain.memberMission.entity.MemberMission;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberMissionRepository extends JpaRepository<MemberMission, Long> {
+
+    List<MemberMission> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/chaeum/api/domain/memberMission/repository/MemberMissionRepository.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/repository/MemberMissionRepository.java
@@ -1,0 +1,4 @@
+package com.chaeum.api.domain.memberMission.repository;
+
+public interface MemberMissionRepository {
+}

--- a/src/main/java/com/chaeum/api/domain/memberMission/service/MemberMissionRandomService.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/service/MemberMissionRandomService.java
@@ -1,0 +1,52 @@
+package com.chaeum.api.domain.memberMission.service;
+
+import static com.chaeum.api.global.utils.MemberMissionConstants.ATTENDANCE_PROGRESS_MIN;
+import static com.chaeum.api.global.utils.MemberMissionConstants.CAT_PROGRESS_MAX;
+import static com.chaeum.api.global.utils.MemberMissionConstants.CAT_PROGRESS_MIN;
+import static com.chaeum.api.global.utils.MemberMissionConstants.DONATION_PROGRESS_MAX;
+import static com.chaeum.api.global.utils.MemberMissionConstants.DONATION_PROGRESS_MIN;
+import static com.chaeum.api.global.utils.MemberMissionConstants.FRIEND_PROGRESS_MAX;
+import static com.chaeum.api.global.utils.MemberMissionConstants.FRIEND_PROGRESS_MIN;
+import static com.chaeum.api.global.utils.MemberMissionConstants.ITEM_PROGRESS_MIN;
+import static com.chaeum.api.global.utils.MemberMissionConstants.MEMBER_MISSION_ASSIGN_COUNT;
+
+import com.chaeum.api.domain.mission.entity.Mission;
+import com.chaeum.api.domain.mission.entity.MissionType;
+import com.chaeum.api.domain.mission.service.MissionService;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberMissionRandomService {
+
+    private final MissionService missionService;
+
+    @Transactional(readOnly = true)
+    public List<Mission> getRandomMissions() {
+        List<Mission> missions = missionService.findAllMissions();
+        Collections.shuffle(missions);
+        return missions.stream()
+            .limit(MEMBER_MISSION_ASSIGN_COUNT)
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public int getRandomProgressCount(MissionType type) {
+        return switch (type) {
+            case ATTENDANCE -> ATTENDANCE_PROGRESS_MIN;
+            case ITEM -> ITEM_PROGRESS_MIN;
+            case FRIEND -> getRandomNumberInRange(FRIEND_PROGRESS_MIN, FRIEND_PROGRESS_MAX);
+            case DONATION -> getRandomNumberInRange(DONATION_PROGRESS_MIN, DONATION_PROGRESS_MAX);
+            case CAT -> getRandomNumberInRange(CAT_PROGRESS_MIN, CAT_PROGRESS_MAX);
+        };
+    }
+
+    private int getRandomNumberInRange(int min, int max) {
+        return ThreadLocalRandom.current().nextInt(min, max + 1);
+    }
+}

--- a/src/main/java/com/chaeum/api/domain/memberMission/service/MemberMissionRandomService.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/service/MemberMissionRandomService.java
@@ -1,13 +1,13 @@
 package com.chaeum.api.domain.memberMission.service;
 
 import static com.chaeum.api.global.utils.MemberMissionConstants.ATTENDANCE_PROGRESS_MIN;
-import static com.chaeum.api.global.utils.MemberMissionConstants.CAT_PROGRESS_MAX;
-import static com.chaeum.api.global.utils.MemberMissionConstants.CAT_PROGRESS_MIN;
+import static com.chaeum.api.global.utils.MemberMissionConstants.CAT_EXP_PROGRESS_MAX;
+import static com.chaeum.api.global.utils.MemberMissionConstants.CAT_EXP_PROGRESS_MIN;
+import static com.chaeum.api.global.utils.MemberMissionConstants.CAT_INTERACTION_PROGRESS_MAX;
+import static com.chaeum.api.global.utils.MemberMissionConstants.CAT_INTERACTION_PROGRESS_MIN;
 import static com.chaeum.api.global.utils.MemberMissionConstants.DONATION_PROGRESS_MAX;
 import static com.chaeum.api.global.utils.MemberMissionConstants.DONATION_PROGRESS_MIN;
-import static com.chaeum.api.global.utils.MemberMissionConstants.FRIEND_PROGRESS_MAX;
-import static com.chaeum.api.global.utils.MemberMissionConstants.FRIEND_PROGRESS_MIN;
-import static com.chaeum.api.global.utils.MemberMissionConstants.ITEM_PROGRESS_MIN;
+import static com.chaeum.api.global.utils.MemberMissionConstants.ITEM_WEAR_PROGRESS_MIN;
 import static com.chaeum.api.global.utils.MemberMissionConstants.MEMBER_MISSION_ASSIGN_COUNT;
 
 import com.chaeum.api.domain.mission.entity.Mission;
@@ -39,10 +39,10 @@ public class MemberMissionRandomService {
     public int getRandomProgressCount(MissionType type) {
         return switch (type) {
             case ATTENDANCE -> ATTENDANCE_PROGRESS_MIN;
-            case ITEM -> ITEM_PROGRESS_MIN;
-            case FRIEND -> getRandomNumberInRange(FRIEND_PROGRESS_MIN, FRIEND_PROGRESS_MAX);
+            case CAT_EXP -> getRandomNumberInRange(CAT_EXP_PROGRESS_MIN, CAT_EXP_PROGRESS_MAX);
+            case CAT_INTERACTION -> getRandomNumberInRange(CAT_INTERACTION_PROGRESS_MIN, CAT_INTERACTION_PROGRESS_MAX);
             case DONATION -> getRandomNumberInRange(DONATION_PROGRESS_MIN, DONATION_PROGRESS_MAX);
-            case CAT -> getRandomNumberInRange(CAT_PROGRESS_MIN, CAT_PROGRESS_MAX);
+            case ITEM_WEAR -> ITEM_WEAR_PROGRESS_MIN;
         };
     }
 

--- a/src/main/java/com/chaeum/api/domain/memberMission/service/MemberMissionService.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/service/MemberMissionService.java
@@ -1,0 +1,4 @@
+package com.chaeum.api.domain.memberMission.service;
+
+public class MemberMissionService {
+}

--- a/src/main/java/com/chaeum/api/domain/memberMission/service/MemberMissionService.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/service/MemberMissionService.java
@@ -9,6 +9,7 @@ import com.chaeum.api.domain.memberMission.repository.MemberMissionRepository;
 import com.chaeum.api.domain.mission.entity.Mission;
 import com.chaeum.api.domain.mission.entity.MissionType;
 import com.chaeum.api.global.auth.util.LoginMemberProvider;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +29,7 @@ public class MemberMissionService {
     @Transactional
     public List<MemberMissionResponse> getMemberMissions() {
         Long memberId = loginMemberProvider.getCurrentLoginMemberId();
-        List<MemberMission> missions = refreshOrGenerateMemberMissions(memberId);
+        List<MemberMission> missions = getOrGenerateMemberMissions(memberId);
         return missions.stream()
             .map(MemberMissionResponse::toDto)
             .toList();
@@ -43,7 +44,17 @@ public class MemberMissionService {
             .forEach(MemberMission::increaseProgress);
     }
 
-    private List<MemberMission> refreshOrGenerateMemberMissions(Long memberId) {
+    @Transactional
+    public void increaseProgressByType(MissionType missionType, BigInteger amount) {
+        int intAmount = amount.intValue();
+        Long memberId = loginMemberProvider.getCurrentLoginMemberId();
+        List<MemberMission> missions = findMissionsByMemberId(memberId);
+        missions.stream()
+            .filter(mission -> mission.getMission().getType() == missionType)
+            .forEach(mission -> mission.increaseProgress(intAmount));
+    }
+
+    private List<MemberMission> getOrGenerateMemberMissions(Long memberId) {
         List<MemberMission> existingMissions = memberMissionRepository.findByMemberId(memberId);
         LocalDate today = LocalDate.now();
         boolean allToday = existingMissions.stream()
@@ -75,8 +86,7 @@ public class MemberMissionService {
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정 초기화
     @Transactional
     public void resetAllMemberMissions() {
-        List<MemberMission> missions = memberMissionRepository.findAll();
-        missions.forEach(MemberMission::reset);
+        memberMissionRepository.deleteAllInBatch();
     }
 
     public List<MemberMission> findMissionsByMemberId(Long memberId) {

--- a/src/main/java/com/chaeum/api/domain/memberMission/service/MemberMissionService.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/service/MemberMissionService.java
@@ -1,4 +1,85 @@
 package com.chaeum.api.domain.memberMission.service;
 
+import static com.chaeum.api.global.utils.MemberMissionConstants.MEMBER_MISSION_ASSIGN_COUNT;
+
+import com.chaeum.api.domain.member.entity.Member;
+import com.chaeum.api.domain.memberMission.dto.response.MemberMissionResponse;
+import com.chaeum.api.domain.memberMission.entity.MemberMission;
+import com.chaeum.api.domain.memberMission.repository.MemberMissionRepository;
+import com.chaeum.api.domain.mission.entity.Mission;
+import com.chaeum.api.domain.mission.entity.MissionType;
+import com.chaeum.api.global.auth.util.LoginMemberProvider;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberMissionService {
+
+    private final MemberMissionRepository memberMissionRepository;
+    private final LoginMemberProvider loginMemberProvider;
+    private final MemberMissionRandomService memberMissionRandomService;
+
+    @Transactional
+    public List<MemberMissionResponse> getMemberMissions() {
+        Long memberId = loginMemberProvider.getCurrentLoginMemberId();
+        List<MemberMission> missions = refreshOrGenerateMemberMissions(memberId);
+        return missions.stream()
+            .map(MemberMissionResponse::toDto)
+            .toList();
+    }
+
+    @Transactional
+    public void increaseProgressByType(MissionType missionType) {
+        Long memberId = loginMemberProvider.getCurrentLoginMemberId();
+        List<MemberMission> missions = findMissionsByMemberId(memberId);
+        missions.stream()
+            .filter(mission -> mission.getMission().getType() == missionType)
+            .forEach(MemberMission::increaseProgress);
+    }
+
+    private List<MemberMission> refreshOrGenerateMemberMissions(Long memberId) {
+        List<MemberMission> existingMissions = memberMissionRepository.findByMemberId(memberId);
+        LocalDate today = LocalDate.now();
+        boolean allToday = existingMissions.stream()
+            .allMatch(m -> m.getUpdatedAt().toLocalDate().isEqual(today));
+
+        // 오늘 받은 미션이 모두 존재하면 그대로 반환
+        if (allToday) {
+            return existingMissions.stream()
+                .limit(MEMBER_MISSION_ASSIGN_COUNT)
+                .toList();
+        }
+
+        // 이전 날짜 미션이 하나라도 있으면 전체 삭제 후 새로 생성
+        memberMissionRepository.deleteAll(existingMissions);
+
+        Member member = loginMemberProvider.getCurrentLoginMember();
+        List<Mission> missions = memberMissionRandomService.getRandomMissions();
+        List<MemberMission> newMissions = missions.stream()
+            .map(mission -> MemberMission.create(
+                member,
+                mission,
+                memberMissionRandomService.getRandomProgressCount(mission.getType())
+            ))
+            .toList();
+
+        return memberMissionRepository.saveAll(newMissions);
+    }
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정 초기화
+    @Transactional
+    public void resetAllMemberMissions() {
+        List<MemberMission> missions = memberMissionRepository.findAll();
+        missions.forEach(MemberMission::reset);
+    }
+
+    public List<MemberMission> findMissionsByMemberId(Long memberId) {
+        return memberMissionRepository.findByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/chaeum/api/domain/memberMission/service/MemberMissionService.java
+++ b/src/main/java/com/chaeum/api/domain/memberMission/service/MemberMissionService.java
@@ -50,7 +50,7 @@ public class MemberMissionService {
             .allMatch(m -> m.getUpdatedAt().toLocalDate().isEqual(today));
 
         // 오늘 받은 미션이 모두 존재하면 그대로 반환
-        if (allToday) {
+        if (!existingMissions.isEmpty() && allToday) {
             return existingMissions.stream()
                 .limit(MEMBER_MISSION_ASSIGN_COUNT)
                 .toList();

--- a/src/main/java/com/chaeum/api/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/chaeum/api/domain/mission/controller/MissionController.java
@@ -50,8 +50,6 @@ public class MissionController {
         return ApiResponse.success(missionResponse);
     }
 
-    // 내 미션 조회 컨트롤러 구현
-
     @Operation(summary = "조건별 미션 조회", description = "ADMIN 이상 조회 가능")
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/condition")

--- a/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionCreateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionCreateRequest.java
@@ -26,6 +26,6 @@ public class MissionCreateRequest {
     private String missionImageUrl;
 
     @NotNull
-    @Schema(description = "미션 종류", example = "CHECK_IN")
+    @Schema(description = "미션 타입", example = "ATTENDANCE")
     private MissionType type;
 }

--- a/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionUpdateRequest.java
+++ b/src/main/java/com/chaeum/api/domain/mission/dto/request/MissionUpdateRequest.java
@@ -26,6 +26,6 @@ public class MissionUpdateRequest {
     private String missionImage;
 
     @NotNull
-    @Schema(description = "미션 유형", example = "CHECK_IN")
+    @Schema(description = "미션 타입", example = "ATTENDANCE")
     private MissionType type;
 }

--- a/src/main/java/com/chaeum/api/domain/mission/entity/MissionType.java
+++ b/src/main/java/com/chaeum/api/domain/mission/entity/MissionType.java
@@ -7,10 +7,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum MissionType {
 
-    CHECK_IN("CHECK_IN", "출석 미션"),
+    ATTENDANCE("ATTENDANCE", "출석 미션"),
+    CAT("CAT", "고양이 상호작용 미션"),
     DONATION("DONATION", "기부 미션"),
-    REFERRAL("REFERRAL", "친구 초대 미션"),
-    CUSTOM("CUSTOM", "커스텀 미션");
+    FRIEND("FRIEND", "친구 미션"),
+    ITEM("ITEM", "아이템 착용 미션");
 
     private final String key;
     private final String description;

--- a/src/main/java/com/chaeum/api/domain/mission/entity/MissionType.java
+++ b/src/main/java/com/chaeum/api/domain/mission/entity/MissionType.java
@@ -8,10 +8,10 @@ import lombok.Getter;
 public enum MissionType {
 
     ATTENDANCE("ATTENDANCE", "출석 미션"),
-    CAT("CAT", "고양이 상호작용 미션"),
+    CAT_EXP("CAT_EXP", "고양이 경험치 획득 미션"),
+    CAT_INTERACTION("CAT_INTERACTION", "고양이 상호작용 미션"),
     DONATION("DONATION", "기부 미션"),
-    FRIEND("FRIEND", "친구 미션"),
-    ITEM("ITEM", "아이템 착용 미션");
+    ITEM_WEAR("ITEM_WEAR", "아이템 착용 미션");
 
     private final String key;
     private final String description;

--- a/src/main/java/com/chaeum/api/domain/mission/service/MissionService.java
+++ b/src/main/java/com/chaeum/api/domain/mission/service/MissionService.java
@@ -35,8 +35,6 @@ public class MissionService {
         return MissionResponse.toDto(mission);
     }
 
-    // 내 미션들만 볼 수 있는 서비스 로직 작성
-
     @Transactional(readOnly = true)
     public IdCursorResult<MissionResponse> getMissionsByCondition(String missionName, MissionType missionType,
         Long cursor, int limit) {
@@ -67,6 +65,10 @@ public class MissionService {
     public Long delete(Long missionId) {
         missionRepository.deleteById(missionId);
         return missionId;
+    }
+
+    public List<Mission> findAllMissions() {
+        return missionRepository.findAll();
     }
 
     private Mission findById(Long missionId) {

--- a/src/main/java/com/chaeum/api/domain/missionProgress/controller/MissionProgressController.java
+++ b/src/main/java/com/chaeum/api/domain/missionProgress/controller/MissionProgressController.java
@@ -1,4 +1,0 @@
-package com.chaeum.api.domain.missionProgress.controller;
-
-public class MissionProgressController {
-}

--- a/src/main/java/com/chaeum/api/domain/missionProgress/repository/MissionProgressRepository.java
+++ b/src/main/java/com/chaeum/api/domain/missionProgress/repository/MissionProgressRepository.java
@@ -1,4 +1,0 @@
-package com.chaeum.api.domain.missionProgress.repository;
-
-public interface MissionProgressRepository {
-}

--- a/src/main/java/com/chaeum/api/domain/missionProgress/service/MissionProgressService.java
+++ b/src/main/java/com/chaeum/api/domain/missionProgress/service/MissionProgressService.java
@@ -1,4 +1,0 @@
-package com.chaeum.api.domain.missionProgress.service;
-
-public class MissionProgressService {
-}

--- a/src/main/java/com/chaeum/api/global/utils/MemberMissionConstants.java
+++ b/src/main/java/com/chaeum/api/global/utils/MemberMissionConstants.java
@@ -9,17 +9,15 @@ public class MemberMissionConstants {
     public static final int MEMBER_MISSION_ASSIGN_COUNT = 5;
 
     public static final int ATTENDANCE_PROGRESS_MIN = 1;
-    public static final int ATTENDANCE_PROGRESS_MAX = 1;
 
-    public static final int CAT_PROGRESS_MIN = 1;
-    public static final int CAT_PROGRESS_MAX = 5;
+    public static final int CAT_EXP_PROGRESS_MIN = 10;
+    public static final int CAT_EXP_PROGRESS_MAX = 50;
+
+    public static final int CAT_INTERACTION_PROGRESS_MIN = 1;
+    public static final int CAT_INTERACTION_PROGRESS_MAX = 5;
 
     public static final int DONATION_PROGRESS_MIN = 1;
     public static final int DONATION_PROGRESS_MAX = 3;
 
-    public static final int FRIEND_PROGRESS_MIN = 1;
-    public static final int FRIEND_PROGRESS_MAX = 3;
-
-    public static final int ITEM_PROGRESS_MIN = 1;
-    public static final int ITEM_PROGRESS_MAX = 1;
+    public static final int ITEM_WEAR_PROGRESS_MIN = 1;
 }

--- a/src/main/java/com/chaeum/api/global/utils/MemberMissionConstants.java
+++ b/src/main/java/com/chaeum/api/global/utils/MemberMissionConstants.java
@@ -10,8 +10,8 @@ public class MemberMissionConstants {
 
     public static final int ATTENDANCE_PROGRESS_MIN = 1;
 
-    public static final int CAT_EXP_PROGRESS_MIN = 10;
-    public static final int CAT_EXP_PROGRESS_MAX = 50;
+    public static final int CAT_EXP_PROGRESS_MIN = 100;
+    public static final int CAT_EXP_PROGRESS_MAX = 500;
 
     public static final int CAT_INTERACTION_PROGRESS_MIN = 1;
     public static final int CAT_INTERACTION_PROGRESS_MAX = 5;

--- a/src/main/java/com/chaeum/api/global/utils/MemberMissionConstants.java
+++ b/src/main/java/com/chaeum/api/global/utils/MemberMissionConstants.java
@@ -1,0 +1,25 @@
+package com.chaeum.api.global.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberMissionConstants {
+
+    public static final int MEMBER_MISSION_ASSIGN_COUNT = 5;
+
+    public static final int ATTENDANCE_PROGRESS_MIN = 1;
+    public static final int ATTENDANCE_PROGRESS_MAX = 1;
+
+    public static final int CAT_PROGRESS_MIN = 1;
+    public static final int CAT_PROGRESS_MAX = 5;
+
+    public static final int DONATION_PROGRESS_MIN = 1;
+    public static final int DONATION_PROGRESS_MAX = 3;
+
+    public static final int FRIEND_PROGRESS_MIN = 1;
+    public static final int FRIEND_PROGRESS_MAX = 3;
+
+    public static final int ITEM_PROGRESS_MIN = 1;
+    public static final int ITEM_PROGRESS_MAX = 1;
+}


### PR DESCRIPTION
## ⭐️ Overview

> #93

회원별 미션 생성 및 진행 상황 조회 기능을 구현했습니다.
진행도에 따라 미션 상태 및 카운트가 업데이트되며, 매일 자정 기준 미완료 미션은 자동 실패 처리됩니다.


## 🔧 Tasks

- 내 미션 생성 로직 구현
- 내 미션 목록 조회 로직 구현
- 도메인별 미션 카운트 증가 로직 구현
- 미션 상태 및 진행도 관리 로직 구현
- 매일 자정 기준 실패 처리 로직 구현


## 📝 Additional Notes

### 구조 및 설계 의도

- 기존 `Mission`은 이름/설명 등을 포함하는 정적 데이터로 유지하고, 회원과 관련된 동적 정보는 `MemberMission` 엔티티에서 관리합니다.
- 기존 `MissionProgress` 네이밍을 중간 테이블 컨벤션에 맞춰 `MemberMission`으로 리팩토링했습니다.

### 미션 생성 및 조회 흐름

- 미션 조회 시 오늘 날짜의 미션이 존재하면 그대로 반환하고, 존재하지 않거나 이전 날짜인 경우 새롭게 5개의 미션을 랜덤 생성해 제공합니다.
- 미션은 최대 5개로 제한되며, MissionType은 총 5가지입니다:
  - 출석(`ATTENDANCE`), 고양이 경험치 획득(`CAT_EXP`), 고양이 상호작용(`CAT_INTERACTION`), 
  기부 횟수(`DONATION`), 아이템 착용(`ITEM_WEAR`)

### 진행도 및 랜덤 로직 처리

- 미션별 진행도 범위는 `/global/utils`에서 상수로 관리됩니다.  
  (예: 출석 미션은 최대 1, 고양이 경험치 미션은 100~1000단위까지 다양)
- `ThreadLocalRandom.current()`를 통해 서비스 로직 객체 생성을 지양하였습니다.

### 미션 초기화 및 상태 관리

- 전체 회원의 미션들을 자정마다 일괄 초기화 후 생성하는 방식은 비효율적이라고 판단해서, 
최대한 on-demand 방식을 고려하며 아래처럼 설계했습니다.
- 기존 미션이 어제 날짜거나 유효하지 않으면 삭제 후 새로 생성됩니다.
- 초기화 시에는 `@Scheduled` 작업으로 전체 member_mission 테이블을 `deleteAllInBatch()`로 삭제하여 성능을 최적화했습니다.

### 도메인 연동 및 호출 순서 정리

- 각 도메인에서 비즈니스 로직 처리 후 `increaseProgressByType()`을 호출하여 미션 연동 처리했습니다.
- 도메인 중에 연동된 로직이 많은 경우 우선순위를 `미션 > 칭호 > 알림` 순으로 설계했습니다.

## 📸 Screenshot

- 첫 미션 조회 시  
  미션 페이지에 처음 진입하면 랜덤으로 5개의 미션이 자동 생성됩니다.  
  <img src="https://github.com/user-attachments/assets/020919e6-0f9c-4198-b07a-a2b46ae962be" width="500" />

- 고양이 상호작용 및 경험치 미션 1회 수행  
  고양이와 상호작용 아이템을 2번 사용하여 경험치 202을 획득하고, 미션 상태가 `IN_PROGRESS`로 변경된 모습입니다.
  
  <img src="https://github.com/user-attachments/assets/8888c657-0bc9-49c8-9dbf-b5cc4facc9c0" width="500" />

- 출석 1회 완료 후  
  출석체크 후 해당 미션 상태가 `COMPLETED`로 변경된 모습입니다.
  <img src="https://github.com/user-attachments/assets/4e94881d-65e9-4af6-b0a0-5430fd983fef" width="500" />

- 기부 미션 2회 수행  
  기부 미션의 진행도가 누적되어 카운트 2로 증가 후, 미션 상태가 `IN_PROGRESS`로 변경된 모습입니다.
  <img src="https://github.com/user-attachments/assets/069afa48-31ab-4df0-b349-d1c827b1efa0" width="500" />

- 자정 기준 미완료 미션 처리 
  자정이 지나면서 미완료된 미션은 카운트가 0으로 초기화되고, 상태가 `FAILED`로 변경됩니다. (테스트를 위해 자정 5분 전으로 스케줄 설정)  
  <img src="https://github.com/user-attachments/assets/bab1ebe3-957a-4a29-8fdd-1d986adafbf9" width="500" />

- 자정 이후 미션 재조회 시  
  실패 처리된 이전 미션 대신 새로운 미션 5개를 지급받은 모습입니다.  
  <img src="https://github.com/user-attachments/assets/4f663b42-fbbf-4ce7-99c6-6dbde1be25fe" width="500" />
