### PR TITLE
refactor: 펀딩을 생성한 회원의 id 필드 추가

### DIFF
--- a/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingResponse.java
+++ b/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingResponse.java
@@ -18,6 +18,8 @@ public class FundingResponse implements IdProvider {
 
     private Long id;
 
+    private Long memberId;
+
     private String title;
 
     private String content;
@@ -42,8 +44,10 @@ public class FundingResponse implements IdProvider {
 
     public static FundingResponse toDto(Funding funding) {
         List<UploadedFile> files = funding.getFundingImages();
+        Long memberId = funding.getMember().getId();
         return FundingResponse.builder()
             .id(funding.getId())
+            .memberId(memberId)
             .title(funding.getTitle())
             .content(funding.getContent())
             .fundingImages(ExternalFileResponse.toListDto(files))


### PR DESCRIPTION
## ⭐️ Overview

> #117 

펀딩을 생성한 회원의 id 필드를 추가했습니다.

## 🔧 Tasks

- 펀딩을 생성한 회원의 id 필드 추가

## 📸 Screenshot
<img width="390" alt="image" src="https://github.com/user-attachments/assets/97b910b2-da22-4b2a-8b11-edbad702ca98" />
