### PR TITLE
fix: 고양이 상호작용 아이템 개수 소모 수정 완료

### DIFF
--- a/src/main/java/com/chaeum/api/domain/inventory/service/InventoryService.java
+++ b/src/main/java/com/chaeum/api/domain/inventory/service/InventoryService.java
@@ -120,6 +120,7 @@ public class InventoryService {
     public void useInteractionItem(Long inventoryId) {
         Inventory inventory = findByInventoryId(inventoryId);
         inventory.getItem().validateCategory(ItemCategory.INTERACTION);
+        inventory.removeQuantity();
         BigInteger exp = ExpConstants.INTERACTION;
         catService.addExperience(exp);
         memberMissionService.increaseProgressByType(MissionType.CAT_INTERACTION);


### PR DESCRIPTION
## ⭐️ Overview

> #123 

고양이 상호작용 아이템을 사용해도 개수가 줄어들지 않는 버그를 수정했습니다.

## 🔧 Tasks

- `useInteractionItem`에 개수 소모 메서드 호출

## 📸 Screenshot

![스크린샷 2025-06-03 오후 9 51 17](https://github.com/user-attachments/assets/8d26fc7e-b6ef-4ccf-9c1b-f37fdc2c89e4)
