### PR TITLE
refactor: 펀딩 후기 목록에 fundingId 추가 완료

### DIFF
--- a/src/main/java/com/chaeum/api/domain/review/dto/response/ReviewSummaryResponse.java
+++ b/src/main/java/com/chaeum/api/domain/review/dto/response/ReviewSummaryResponse.java
@@ -15,6 +15,8 @@ public class ReviewSummaryResponse implements CreatedAtProvider {
 
     private Long id;
 
+    private Long fundingId;
+
     private String title;
 
     private ExternalFileResponse reviewImage;
@@ -29,6 +31,7 @@ public class ReviewSummaryResponse implements CreatedAtProvider {
 
         return ReviewSummaryResponse.builder()
             .id(review.getId())
+            .fundingId(review.getFunding().getId())
             .title(review.getTitle())
             .reviewImage(imageDto)
             .createdAt(review.getCreatedAt())


### PR DESCRIPTION
## ⭐️ Overview

> #124 

기존의 리뷰 조회는 `fundingId`로 조회가 가능합니다. 따라서, 펀딩 목록 조회에서 `fundingId`를 통해 리뷰 상세를 조회할 수 있도록 해당 DTO에 펀딩 ID 필드를 추가했습니다.

## 🔧 Tasks

- `ReviewSummaryResponse`에 `fundingId` 추가


## 📸 Screenshot

![스크린샷 2025-06-03 오후 10 01 53](https://github.com/user-attachments/assets/9806bc86-1014-47a0-859a-3a3484e96383)
