### PR TITLE
refactor: 펀딩 종료일 검증 로직 추가

### DIFF
--- a/src/main/java/com/chaeum/api/domain/funding/entity/Funding.java
+++ b/src/main/java/com/chaeum/api/domain/funding/entity/Funding.java
@@ -22,6 +22,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import lombok.AccessLevel;
@@ -134,6 +135,19 @@ public class Funding extends BaseEntity {
     public void validateStatusCompleted() {
         if (this.status != FundingStatus.COMPLETED) {
             throw ChaeumException.from(ErrorCode.FUNDING_IS_NOT_COMPLETED);
+        }
+    }
+
+    public void validateEndDateWithin30Days() {
+        if (this.endDate == null) {
+            throw ChaeumException.from(ErrorCode.INVALID_DATE);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        long daysBetween = ChronoUnit.DAYS.between(now.toLocalDate(), this.endDate.toLocalDate());
+
+        if (daysBetween > 30) {
+            throw ChaeumException.from(ErrorCode.END_DATE_EXCEEDS_LIMIT);
         }
     }
 

--- a/src/main/java/com/chaeum/api/domain/funding/service/FundingService.java
+++ b/src/main/java/com/chaeum/api/domain/funding/service/FundingService.java
@@ -42,6 +42,7 @@ public class FundingService {
         Member member = loginMemberProvider.getCurrentLoginMember();
         List<UploadedFile> files = fileService.getUploadedFilesByUrls(fundingCreateRequest.getImageUrls());
         Funding funding = Funding.toEntity(fundingCreateRequest, files, member);
+        funding.validateEndDateWithin30Days();
         Funding savedFunding = fundingRepository.save(funding);
 
         eventPublisher.publishEvent(
@@ -106,6 +107,7 @@ public class FundingService {
         Funding funding = findById(fundingId);
         List<UploadedFile> files = fileService.getUploadedFilesByUrls(fundingUpdateRequest.getImageUrls());
         funding.update(files, fundingUpdateRequest);
+        funding.validateEndDateWithin30Days();
         return funding.getId();
     }
 

--- a/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
+++ b/src/main/java/com/chaeum/api/global/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     INVALID_DATE(HttpStatus.BAD_REQUEST, "유효하지 않은 날짜입니다."),
     ALREADY_ATTENDED_TODAY(HttpStatus.BAD_REQUEST, "이미 오늘 출석을 완료했습니다."),
     ALREADY_HAS_TITLE(HttpStatus.BAD_REQUEST, "이미 보유한 칭호입니다."),
+    END_DATE_EXCEEDS_LIMIT(HttpStatus.BAD_REQUEST, "펀딩 종료일은 현재로부터 최대 30일 이내여야 합니다."),
 
     // 401: UNAUTHORIZED (인증 실패)
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),


### PR DESCRIPTION
## ⭐️ Overview

> #125

펀딩 종료일이 30일 이내인지 검증하는 로직을 추가했습니다.
지나치게 긴 펀딩 기간을 제한하기 위해서 추가했습니다.

## 🔧 Tasks

- 펀딩 종료일 검증 로직 및 에러코드 추가
- 펀딩 생성 및 업데이트 시 검증 메서드 호출

## 📸 Screenshot

현재 날짜 (2025-06-03) 기준으로 테스트 진행
- 2025-06-28 (25일 뒤) → ✅ 펀딩 생성 성공

<img width="288" alt="펀딩 생성" src="https://github.com/user-attachments/assets/a5a457dc-3f18-4da8-be90-0f1fb5b9e236" />

- 2025-07-05 (32일 뒤) → ❌ 펀딩 생성 실패 (30일 초과)
<img width="505" alt="펀딩 생성 X" src="https://github.com/user-attachments/assets/e8cd2bc3-97b1-4304-89c0-7d9f31d8cf1f" />
