### PR TITLE
refactor: 펀딩을 생성한 회원의 이름 추가

### DIFF
--- a/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingResponse.java
+++ b/src/main/java/com/chaeum/api/domain/funding/dto/response/FundingResponse.java
@@ -18,7 +18,7 @@ public class FundingResponse implements IdProvider {
 
     private Long id;
 
-    private Long memberId;
+    private String name;
 
     private String title;
 
@@ -44,10 +44,9 @@ public class FundingResponse implements IdProvider {
 
     public static FundingResponse toDto(Funding funding) {
         List<UploadedFile> files = funding.getFundingImages();
-        Long memberId = funding.getMember().getId();
         return FundingResponse.builder()
             .id(funding.getId())
-            .memberId(memberId)
+            .name(funding.getMember().getName())
             .title(funding.getTitle())
             .content(funding.getContent())
             .fundingImages(ExternalFileResponse.toListDto(files))


### PR DESCRIPTION
## ⭐️ Overview

> #117

펀딩을 생성한 회원의 이름을 응답 데이터에 포함하도록 수정했습니다.
기존에는 memberId로 조회하여 제공되었으나, 이제는 펀딩 생성자의 이름을 직접 조회하여 반환합니다.

## 🔧 Tasks

- 펀딩을 생성한 회원의 이름 추가

## 📸 Screenshot
<img width="390" alt="image" src="https://github.com/user-attachments/assets/97b910b2-da22-4b2a-8b11-edbad702ca98" />
