### PR TITLE
hotfix: 인벤토리 미보유 시 보상 필터링 중 NPE 발생 문제 해결

### DIFF
--- a/src/main/java/com/chaeum/api/domain/donation/service/DonationRewardService.java
+++ b/src/main/java/com/chaeum/api/domain/donation/service/DonationRewardService.java
@@ -19,6 +19,7 @@ import com.chaeum.api.global.auth.util.LoginMemberProvider;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
@@ -102,7 +103,9 @@ public class DonationRewardService {
             );
 
             // 이미 소유한 아이템 제외
-            Set<Long> ownedItemIds = inventoryService.findItemIdsByMemberId(member.getId());
+            Set<Long> ownedItemIds = Optional.ofNullable(
+                inventoryService.findItemIdsByMemberId(member.getId())
+            ).orElse(Collections.emptySet());
             List<Item> filtered = candidateItems.stream()
                 .filter(item -> !ownedItemIds.contains(item.getId()))
                 .toList();


### PR DESCRIPTION
## ⭐️ Overview

> #137 

보상 지급 시, 이미 소유한 아이템을 제외하기 위해 인벤토리 정보를 조회합니다.<br>
하지만 사용자가 아이템을 하나도 보유하지 않은 경우, 
해당 데이터가 null이 되어 보상 필터링 과정에서 NPE가 발생하던 문제를 확인하여 수정했습니다.

## 🔧 Tasks

- 인벤토리 미보유 시 보상 필터링 중 NPE 발생 문제 해결
